### PR TITLE
MudStaticTextField: Fix HelperText being hidden on lose focus incorrectly

### DIFF
--- a/src/Components/MudStaticTextField.razor
+++ b/src/Components/MudStaticTextField.razor
@@ -82,7 +82,7 @@
                     targetParent.classList.toggle("mud-shrink", !emptyValue);
                 }
 
-                if (helperElement) {
+                if (showOnFocus && helperElement) {
                     helperElement.style.visibility = "hidden";
                 }
             });


### PR DESCRIPTION
Helper text was being hidden on blur, even though `HelperTextOnFocus` was set to false. When false, the test should **always** be shown. 