### PR TITLE
 [feature] Allow executing custom function on adornment click. 

### DIFF
--- a/MudBlazor.StaticInput.sln
+++ b/MudBlazor.StaticInput.sln
@@ -9,9 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StaticSample.Client", "demo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StaticSample", "demo\StaticSample\StaticSample\StaticSample.csproj", "{4513699B-BD7E-42DC-A01A-17AF4D313BC8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StaticInput.UnitTests.Viewer", "tests\StaticInput.UnitTests.Viewer\StaticInput.UnitTests.Viewer.csproj", "{EF0B112F-3C9E-4947-80CF-1F3CA0FBD7FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StaticInput.UnitTests.Viewer", "tests\StaticInput.UnitTests.Viewer\StaticInput.UnitTests.Viewer.csproj", "{EF0B112F-3C9E-4947-80CF-1F3CA0FBD7FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StaticInput.UnitTests", "tests\StaticInput.UnitTests\StaticInput.UnitTests.csproj", "{1CD5FE26-3322-4DD8-BD98-BD8ACBBAECC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StaticInput.UnitTests", "tests\StaticInput.UnitTests\StaticInput.UnitTests.csproj", "{1CD5FE26-3322-4DD8-BD98-BD8ACBBAECC2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
+++ b/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Blazr.RenderState.WASM" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
-	<PackageReference Include="MudBlazor" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+	<PackageReference Include="MudBlazor" Version="7.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.7" />
   </ItemGroup>
 
 </Project>

--- a/demo/StaticSample/StaticSample/Components/Account/Pages/Login.razor
+++ b/demo/StaticSample/StaticSample/Components/Account/Pages/Login.razor
@@ -41,11 +41,12 @@
                     <MudDivider Class="d-flex flex-grow-1" DividerType="DividerType.Middle" Style=@($"border-color:{Colors.Teal.Darken4}") />
                 </MudStack>
 
-                <MudStaticTextField @bind-Value="@Input.Email" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Outlined.Email" autocomplete="username"
+                <MudStaticTextField @bind-Value="@Input.Email" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Outlined.Email" autocomplete="username"
                                     Class="pb-2" Margin="Margin.Dense" Variant="Variant.Outlined" Placeholder="static@mail.com" For="() => Input.Email" />
 
-                <MudStaticTextField @bind-Value="@Input.Password" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Outlined.Lock" autocomplete="current-password"
-                                    Class="pb-2" Margin="Margin.Dense" Variant="Variant.Outlined" Placeholder="Password" InputType="InputType.Password" For="() => Input.Password" />
+                <MudStaticTextField @bind-Value="@Input.Password" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Outlined.VisibilityOff" AdornmentClickFunction="showPassword"
+                                    autocomplete="current-password" Class="pb-2" Margin="Margin.Dense" Variant="Variant.Outlined" Placeholder="Password" 
+                                    InputType="InputType.Password" For="() => Input.Password" />
 
                 <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
                     <MudStaticSwitch @bind-Value="Input.RememberMe" Color="Color.Primary" Label="Remember Me" Typo="Typo.body2" />
@@ -135,3 +136,20 @@
         public bool RememberMe { get; set; }
     }
 }
+
+<script>
+    let timeoutId;
+
+    function showPassword(inputElement, button) {
+        if (inputElement.type === 'password') {
+            inputElement.type = 'text';
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(function () {
+                inputElement.type = 'password';
+            }, 5000);
+        } else {
+            inputElement.type = 'password';
+            clearTimeout(timeoutId);
+        }
+    }
+</script>

--- a/demo/StaticSample/StaticSample/StaticSample.csproj
+++ b/demo/StaticSample/StaticSample/StaticSample.csproj
@@ -9,11 +9,11 @@
   
   <ItemGroup>
     <PackageReference Include="Blazr.RenderState.Server" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Components/MudStaticTextField.razor
+++ b/src/Components/MudStaticTextField.razor
@@ -8,6 +8,50 @@
 }
 
 @code {
+    /// <summary>
+    ///     The name of the JavaScript function that will be invoked when the adornment (button) inside this <see cref="MudStaticTextField{T}"/> is clicked
+    /// </summary>
+    /// <remarks>
+    /// <term>Parameters</term>
+    /// <description>(required)</description>
+    /// <list type="bullet">
+    ///     <item>
+    ///         <term>inputElement</term>
+    ///         <description>The input element associated with the <see cref="MudStaticTextField{T}"/>.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term>eventTrigger</term>
+    ///         <description>The button element (adornment button) that triggered the event.</description>
+    ///     </item>
+    /// </list>
+    /// <example>
+    ///     Example: Setting the AdornmentClickFunction to "showPassword" executes the 'showPassword' function when clicked.    
+    /// <code>
+    /// -------------------------------------------------
+    /// MudStaticTextField @bind-Value="@Input.Password" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Outlined.Lock"
+    ///                    AdornmentClickFunction="showPassword" InputType="InputType.Password" For="() => Input.Password"
+    /// -------------------------------------------------
+    /// </code>
+    /// <code>
+    ///    let timeoutId;
+    ///
+    ///    function showPassword(inputElement, button) {
+    ///        if (inputElement.type === 'password') {
+    ///            inputElement.type = 'text';
+    ///            clearTimeout(timeoutId);
+    ///            timeoutId = setTimeout(function () {
+    ///                inputElement.type = 'password';
+    ///            }, 5000);
+    ///        } else {
+    ///            inputElement.type = 'password';
+    ///            clearTimeout(timeoutId);
+    ///        }
+    ///    }
+    /// </code>
+    /// ------------------------------------------------------------------------
+    /// </example>
+    /// </remarks>
+    [Parameter] public string? AdornmentClickFunction { get; set; }
     [Parameter] public Expression<Func<string>>? ValueExpression { get; set; }
 
     private string _name = string.Empty;
@@ -22,6 +66,11 @@
         UserAttributes["data-static-id"] = _elementId;
         UserAttributes["name"] = _name;
 
+        if (AdornmentClickFunction is not null)
+        {
+            base.OnAdornmentClick = EventCallback.Factory.Create<MouseEventArgs>(this, () => null!);
+        }
+        
         base.OnParametersSet();
     }
 
@@ -53,7 +102,6 @@
                InputType.Week or
                InputType.Time;
     }
-
 }
 
 <script>
@@ -61,6 +109,7 @@
         const inputElement = document.querySelector('[data-static-id="@_elementId"]');
         const shrinkLabel = @HasDefaultContent.ToString().ToLower();
         const showOnFocus = @HelperTextOnFocus.ToString().ToLower();
+        const onAdornmentClick = '@AdornmentClickFunction';
 
         if (inputElement && (!shrinkLabel || showOnFocus)) {
             const parentElement = inputElement.closest(".mud-input-control");
@@ -86,6 +135,20 @@
                     helperElement.style.visibility = "hidden";
                 }
             });
+        }
+
+        if (onAdornmentClick && onAdornmentClick.trim().length > 0) 
+        {
+            const inputControl = inputElement.closest(".mud-input-control");
+            const buttonElement = inputControl.querySelector('button');
+
+            if (buttonElement) {
+                buttonElement.addEventListener('click', function (event) {
+                    if (typeof window[onAdornmentClick] === 'function') {
+                        window[onAdornmentClick](inputElement, event.target);
+                    }
+                });
+            }
         }
     })();
 </script>

--- a/src/MudBlazor.StaticInput.csproj
+++ b/src/MudBlazor.StaticInput.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MudBlazor" Version="7.0.0" />
+        <PackageReference Include="MudBlazor" Version="7.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/TextField/TextFieldAdornmentTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/TextField/TextFieldAdornmentTest.razor
@@ -1,0 +1,34 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+@inject NavigationManager NavigationManager
+
+<EditForm Model="Model" method="post" OnValidSubmit="OnValidSubmit" FormName="Validate">
+    <DataAnnotationsValidator />
+
+    <MudStaticTextField @bind-Value="@Model.Email" For="() => Model.Email" Label="Email" Placeholder="static@mail.com"
+                        Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Outlined.Email"
+                        Class="pb-2" Margin="Margin.Dense" Variant="Variant.Outlined" />
+    <MudStaticTextField @bind-Value="@Model.Password" For="() => Model.Password" Label="Password" Placeholder="Password"
+                        Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Outlined.VisibilityOff"
+                        AdornmentClickFunction="handleAdornmentClick" InputType="InputType.Password"
+                        Class="pb-2" Margin="Margin.Dense" Variant="Variant.Outlined" />
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private TestModel Model { get; set; } = new TestModel();
+
+    private void OnValidSubmit() => NavigationManager.NavigateTo("");
+
+    private sealed class TestModel
+    {
+        public string Email { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}
+
+<script>
+    function handleAdornmentClick(inputElement, buttonElement) {
+        alert('Adornment clicked!');
+    }
+</script>

--- a/tests/StaticInput.UnitTests/Components/TextFieldTests.cs
+++ b/tests/StaticInput.UnitTests/Components/TextFieldTests.cs
@@ -182,5 +182,48 @@ namespace StaticInput.UnitTests.Components
 
             await Expect(Page).ToHaveTitleAsync("Home");
         }
+
+        [Fact]
+        public void TextField_Adornment_Should_Render_Without_Button()
+        {
+            var comp = Context.RenderComponent<TextFieldAdornmentTest>();
+
+            var field = comp.FindComponents<MudStaticTextField<string>>()
+                            .First(x => x.Instance.Label!.Equals("Email", StringComparison.OrdinalIgnoreCase));
+
+            field.Markup.Should().Contain("mud-input-adornment-icon").And.Contain("svg").And.NotContain("<button");
+        }
+
+        [Fact]
+        public void TextField_With_AdornmentClickFunction_Should_Render_AdornmentButton()
+        {
+            var comp = Context.RenderComponent<TextFieldAdornmentTest>();
+
+            var field = comp.FindComponents<MudStaticTextField<string>>()
+                            .First(x => x.Instance.Label!.Equals("Password", StringComparison.OrdinalIgnoreCase));
+
+            field.Markup.Should().Contain("mud-input-adornment-icon").And.Contain("svg").And.Contain("<button");
+        }
+
+        [Fact]
+        public async Task TextField_AdornmentButton_IsClickable()
+        {
+            var url = typeof(TextFieldAdornmentTest).ToQueryString();
+
+            await Page.GotoAsync(url);
+
+            var button = Page.Locator("button");
+            var message = string.Empty;
+
+            Page.Dialog += async (_, dialog) =>
+            {
+                message = dialog.Message;
+                await dialog.AcceptAsync();
+            };
+
+            await button.ClickAsync();
+
+            message.Should().Be("Adornment clicked!");
+        }
     }
 }

--- a/tests/StaticInput.UnitTests/StaticInput.UnitTests.csproj
+++ b/tests/StaticInput.UnitTests/StaticInput.UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.28.9" />
+    <PackageReference Include="bunit" Version="1.29.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -22,8 +22,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.44.0" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Introduces a new MudStaticTextField parameter AdornmentClickFunction
- Updates the Login page in StaticSample to utilze this feature for a show/hide password adornment.
- Includes unit test coverage

Closes #7 

### Description
`AdornmentClickFunction` accepts the name of a JavaScript function to invoke when the adornment is clicked.  

The function should include parameters for the `inputElement` and `eventTrigger`. The input element is the input associated with the `MudStaticTextField`, while the event trigger is the adornment button that raised the event.  

Example: 
```html
<MudStaticTextField @bind-Value="@Input.Password" 
                                 InputType="InputType.Password" 
                                 For="() => Input.Password"
                                 Adornment="Adornment.End" 
                                 AdornmentIcon="@Icons.Material.Outlined.VisibilityOff" 
                                 AdornmentClickFunction="showPassword" />
```
```js
<script>
   let timeoutId;

   function showPassword(inputElement, button) {
       if (inputElement.type === 'password') {
           inputElement.type = 'text';
           clearTimeout(timeoutId);
           timeoutId = setTimeout(function () {
               inputElement.type = 'password';
           }, 5000);
       } else {
           inputElement.type = 'password';
           clearTimeout(timeoutId);
       }
   }
</script>