### PR TITLE
[Fix] Only reload page if a static component exists

### DIFF
--- a/src/Components/MudStaticButton.razor
+++ b/src/Components/MudStaticButton.razor
@@ -34,6 +34,13 @@ else
     /// </summary>
     [Parameter] public string SubmitUrl { get; set; } = string.Empty;
 
+    protected override void OnParametersSet()
+    {
+        UserAttributes["data-static-component"] = true;
+
+        base.OnParametersSet();
+    }
+
     private string GetButtonType() => FormAction switch
     {
         FormAction.Submit => ButtonType.Submit.ToDescriptionString(),

--- a/src/Components/MudStaticCheckBox.razor
+++ b/src/Components/MudStaticCheckBox.razor
@@ -35,6 +35,13 @@
     private string _name = string.Empty;
     private readonly string _elementId = Guid.NewGuid().ToString()[..8];
 
+    protected override void OnParametersSet()
+    {
+        UserAttributes["data-static-component"] = true;
+
+        base.OnParametersSet();
+    }
+
     protected override void OnInitialized()
     {
         var expression = ValueExpression?.ToString();
@@ -51,7 +58,6 @@
 
         base.OnInitialized();
     }
-
 }
 
 <script>

--- a/src/Components/MudStaticSwitch.razor
+++ b/src/Components/MudStaticSwitch.razor
@@ -46,6 +46,13 @@
     private string _name = string.Empty;
     private readonly string _elementId = Guid.NewGuid().ToString()[..8];
 
+    protected override void OnParametersSet()
+    {
+        UserAttributes["data-static-component"] = true;
+
+        base.OnParametersSet();
+    }
+
     protected override void OnInitialized()
     {
         var expression = ValueExpression?.ToString();

--- a/src/Components/MudStaticTextField.razor
+++ b/src/Components/MudStaticTextField.razor
@@ -63,6 +63,7 @@
 
     protected override void OnParametersSet()
     {
+        UserAttributes["data-static-component"] = true;
         UserAttributes["data-static-id"] = _elementId;
         UserAttributes["name"] = _name;
 

--- a/src/wwwroot/NavigationObserver.js
+++ b/src/wwwroot/NavigationObserver.js
@@ -11,7 +11,12 @@ let hasInitialized = false;
 
                 if (currentUrl !== lastUrl) {
                     lastUrl = currentUrl;
-                    window.location.reload();
+
+                    const hasStaticComponent = document.body.querySelector('[data-static-component]') !== null;
+
+                    if (hasStaticComponent) {
+                        window.location.reload();
+                    }
                 }
                 hasInitialized = true;
             }


### PR DESCRIPTION
Based on these [discussions](https://github.com/dotnet/aspnetcore/issues/52273#issuecomment-1892489597), a navigation observer script was added to reload static pages whenever navigation occurred to ensure that the javascript was correctly loaded. However, the script introduced the side effect of reloading pages that were not statically rendered and did not need to be reloaded. 

This change ensures that static component exists on the page before calling reload. 

Closes #9 