### PR TITLE
MudStaticNavMenu: Initial implementation

### DIFF
--- a/demo/StaticSample/StaticSample.Client/Layout/MainLayout.razor
+++ b/demo/StaticSample/StaticSample.Client/Layout/MainLayout.razor
@@ -6,17 +6,15 @@
 
 <MudLayout>
     <MudAppBar Elevation="0">
-		<MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+		<MudStaticNavDrawerToggle Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
+        <MudText Typo="Typo.h6" Style="white-space:nowrap;">Static Input</MudText>
         <MudSpacer />
         <RenderStateViewer Parent="this" Class="px-4" />
         <MudIconButton Icon="@Icons.Custom.Brands.MudBlazor" Color="Color.Inherit" Href="https://mudblazor.com/" Target="_blank" />
         <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/0phois/MudBlazor.StaticInput" Target="_blank" />
     </MudAppBar>
 
-    <MudDrawer @bind-Open="_drawerOpen" Elevation="1">
-        <MudDrawerHeader>
-            <MudText Typo="Typo.h6">Static Input</MudText>
-        </MudDrawerHeader>
+    <MudDrawer @bind-Open="_drawerOpen" Elevation="1" Variant="@DrawerVariant.Responsive" Breakpoint="@Breakpoint.Md" ClipMode="DrawerClipMode.Always">
         <NavMenu />
     </MudDrawer>
     

--- a/demo/StaticSample/StaticSample.Client/Layout/NavMenu.razor
+++ b/demo/StaticSample/StaticSample.Client/Layout/NavMenu.razor
@@ -3,13 +3,15 @@
     <MudNavLink Href="counter" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Add">Counter</MudNavLink>
     <MudNavLink Href="weather" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Weather</MudNavLink>
 
-	<AuthorizeView>
-		<Authorized>
-			<MudNavLink Href="Account/Manage" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">@context.User.Identity?.Name</MudNavLink>
-		</Authorized>
-		<NotAuthorized>
-			<MudNavLink Href="Account/Register" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Register</MudNavLink>
-			<MudNavLink Href="Account/Login" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Login</MudNavLink>
-		</NotAuthorized>
-	</AuthorizeView>
+	<MudStaticNavGroup Icon="@Icons.Material.Filled.AdminPanelSettings" Title="Account" Expanded="true">
+		<AuthorizeView>
+			<Authorized>
+				<MudNavLink Href="Account/Manage" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">@context.User.Identity?.Name</MudNavLink>
+			</Authorized>
+			<NotAuthorized>
+				<MudNavLink Href="Account/Register" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Register</MudNavLink>
+				<MudNavLink Href="Account/Login" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Login</MudNavLink>
+			</NotAuthorized>
+		</AuthorizeView>
+	</MudStaticNavGroup>
 </MudNavMenu>

--- a/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
+++ b/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.10" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\MudBlazor.StaticInput.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/demo/StaticSample/StaticSample.Client/_Imports.razor
+++ b/demo/StaticSample/StaticSample.Client/_Imports.razor
@@ -10,4 +10,5 @@
 @using StaticSample.Client
 @using MudBlazor
 @using MudBlazor.Services
+@using MudBlazor.StaticInput
 @using Blazr.RenderState

--- a/src/Components/NavMenu/MudStaticNavDrawerToggle.razor
+++ b/src/Components/NavMenu/MudStaticNavDrawerToggle.razor
@@ -1,0 +1,41 @@
+﻿@using Microsoft.JSInterop
+
+@namespace MudBlazor.StaticInput
+
+@inherits MudIconButton
+@inject IJSRuntime JsRuntime
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+    /// <summary>
+    /// The id of the <see cref="MudDrawer"/> to toggle
+    /// </summary>
+    /// <remarks>
+    /// If not provided, the first mud-drawer element located within the DOM is used.
+    /// </remarks>
+    [Parameter]
+    public string? DrawerId { get; set; } = "_no_id_provided_";
+
+    private string _elementId = string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        UserAttributes["data-mud-drawer-toggle"] = DrawerId;
+        UserAttributes["data-static-component"] = true;
+        UserAttributes["data-static-id"] = _elementId;
+
+        base.OnClick = EventCallback.Factory.Create<MouseEventArgs>(this, async () => await JsRuntime.InvokeVoidAsync("MudDrawerInterop.toggleDrawer", DrawerId));
+
+        base.OnParametersSet();
+    }
+
+    protected override void OnInitialized()
+    {
+        _elementId = Guid.NewGuid().ToString()[..8];
+
+        base.OnInitialized();
+    }
+}

--- a/src/Components/NavMenu/MudStaticNavDrawerToggle.razor.cs
+++ b/src/Components/NavMenu/MudStaticNavDrawerToggle.razor.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.StaticInput;
+
+/// <summary>
+/// A <see cref="MudIconButton"/> used to toggle the state of the navigation <see cref="MudDrawer"/> 
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///     <item>
+///         <see cref="DrawerClipMode"/> should be set to <see cref="DrawerClipMode.Always"/>
+///     </item>
+///     <item>
+///         <see cref="DrawerVariant.Temporary"/> is not currently supported since the required <see cref="MudOverlay"/> is not implemented
+///     </item>
+/// </list>
+/// </remarks>
+public partial class MudStaticNavDrawerToggle : MudIconButton
+
+{
+    protected new EventCallback<MouseEventArgs> OnClick { get; set; }
+    protected new ButtonType ButtonType { get; set; }
+    protected new string HtmlTag { get; set; } = "button";
+    protected new string? Href { get; set; }
+    protected new string? Target { get; set; }
+    protected new bool ClickPropagation { get; set; }
+}

--- a/src/Components/NavMenu/MudStaticNavGroup.razor
+++ b/src/Components/NavMenu/MudStaticNavGroup.razor
@@ -1,0 +1,64 @@
+﻿@namespace MudBlazor.StaticInput
+
+@inherits MudNavGroup
+
+@{
+    base.BuildRenderTree(__builder);
+}
+
+@code {
+    private string _elementId = string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        UserAttributes["data-static-component"] = true;
+        UserAttributes["data-static-id"] = _elementId;
+
+        base.OnParametersSet();
+    }
+
+    protected override void OnInitialized()
+    {
+        _elementId = Guid.NewGuid().ToString()[..8];
+
+        base.OnInitialized();
+    }
+}
+
+@if (IsStatic()) {
+    <script>
+        (function () {
+            document.addEventListener('DOMContentLoaded', () => {
+                const button = document.querySelector('[data-static-id="@_elementId"] button');
+
+                if (button) {
+                    button.addEventListener('click', (event) => {
+                        const navElement = event.target.closest('nav');
+                        const collapseContainer = navElement.querySelector('.mud-collapse-container');
+                        const expandIcon = navElement.querySelector('.mud-nav-link-expand-icon');
+
+                        if (!collapseContainer || !expandIcon) {
+                            console.warn("Missing required elements for toggling");
+                            return;
+                        }
+
+                        // Check current state
+                        const isExpanded = button.getAttribute('aria-expanded') === "true";
+
+                        // Toggle classes for collapse container
+                        collapseContainer.classList.toggle('mud-collapse-entered', !isExpanded);
+                        collapseContainer.classList.toggle('mud-navgroup-collapse', true);
+                        collapseContainer.classList.remove('mud-collapse-entering');
+                        collapseContainer.setAttribute('aria-hidden', isExpanded);
+
+                        // Toggle classes for expand icon
+                        expandIcon.classList.toggle('mud-transform', !isExpanded);
+
+                        // Update aria-expanded on the button
+                        button.setAttribute('aria-expanded', !isExpanded);
+                    });
+                }
+            });
+        })();
+    </script> 
+}

--- a/src/Components/NavMenu/MudStaticNavGroup.razor.cs
+++ b/src/Components/NavMenu/MudStaticNavGroup.razor.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Http;
+
+namespace MudBlazor.StaticInput;
+
+public partial class MudStaticNavGroup : MudNavGroup
+{
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private bool IsStatic()
+    {
+#if NET9_0_OR_GREATER
+        return !RendererInfo.IsInteractive;
+#else
+        return HttpContext != null;
+#endif
+    }
+}
+

--- a/src/MudBlazor.StaticInput.csproj
+++ b/src/MudBlazor.StaticInput.csproj
@@ -21,6 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="MudBlazor" Version="8.0.0-preview.5" />
     </ItemGroup>
 

--- a/src/wwwroot/NavigationObserver.js
+++ b/src/wwwroot/NavigationObserver.js
@@ -28,17 +28,128 @@ let hasInitialized = false;
                     }
                 });
             });
-            observer.observe(document.body, {
-                childList: true,
-                subtree: true
-            });
+            observer.observe(document.body, { childList: true, subtree: true });
+
             initializeScripts();
         }
+    };
+
+    window.MudDrawerInterop = {
+        initialize: function () {
+            const drawerToggleElements = document.querySelectorAll('[data-mud-drawer-toggle]');
+
+            drawerToggleElements.forEach(element => {
+                element.removeEventListener('click', this.handleToggleDrawer);
+                element.addEventListener('click', this.handleToggleDrawer);
+            });
+
+            const responsiveDrawer = document.querySelectorAll('.mud-drawer-responsive')[0]; 
+
+            if (responsiveDrawer) {
+                MudDrawerInterop.monitorResize(responsiveDrawer);
+            }
+        },
+
+        monitorResize(responsiveDrawer) {
+            const classSections = Array.from(responsiveDrawer.parentElement.classList).find(className => className.includes('responsive')).split('-');
+            const breakpoint = classSections[classSections.length - 2];
+            const position = classSections[classSections.length - 1];
+            const breakpointValue = MudDrawerInterop.getBreakpointValue(breakpoint);
+            const resizeQuery = window.matchMedia(`(min-width: ${breakpointValue}px)`);
+
+            if (responsiveDrawer.parentElement.offsetWidth <= breakpointValue) {
+                MudDrawerInterop.autoCollapse(responsiveDrawer, breakpoint, position);
+            } else {
+                MudDrawerInterop.autoExpand(responsiveDrawer, breakpoint, position);
+            }
+
+            resizeQuery.addEventListener('change', ev => {
+                if (ev.matches) {
+                    MudDrawerInterop.autoExpand(responsiveDrawer, breakpoint, position);
+                }
+                else {
+                    MudDrawerInterop.autoCollapse(responsiveDrawer, breakpoint, position);
+                }
+            })
+        },
+
+        getBreakpointValue(breakpoint) {
+            switch (breakpoint) {
+                case 'xs': return 380;
+                case 'sm': return 600;
+                case 'md': return 960;
+                case 'lg': return 1280;
+                case 'xl': return 1920;
+            }
+        },
+
+        autoCollapse(responsiveDrawer, breakpoint, position) {
+            responsiveDrawer.classList.add('mud-drawer--closed');
+            responsiveDrawer.classList.remove('mud-drawer--open');
+            responsiveDrawer.parentElement.classList.add(`mud-drawer-closed-responsive-${breakpoint}-${position}`)
+            responsiveDrawer.parentElement.classList.remove(`mud-drawer-open-responsive-${breakpoint}-${position}`)
+        },
+
+        autoExpand(responsiveDrawer, breakpoint, position) {
+            responsiveDrawer.classList.add('mud-drawer--open');
+            responsiveDrawer.classList.remove('mud-drawer--closed');
+            responsiveDrawer.parentElement.classList.add(`mud-drawer-open-responsive-${breakpoint}-${position}`)
+            responsiveDrawer.parentElement.classList.remove(`mud-drawer-closed-responsive-${breakpoint}-${position}`)
+        },
+
+        handleToggleDrawer: function (event) {
+            const element = event.currentTarget;
+            const targetDrawerId = element.getAttribute('data-mud-drawer-toggle');
+
+            MudDrawerInterop.toggleDrawer(targetDrawerId);
+        },
+
+        toggleDrawer: function (drawerId) {
+            let mudDrawer;
+
+            if (drawerId === '_no_id_provided_') {
+                mudDrawer = document.querySelectorAll('.mud-drawer')[0];
+            } else {
+                mudDrawer = document.getElementById(drawerId);
+            }
+
+            if (mudDrawer) {
+                mudDrawer.classList.toggle('mud-drawer--open');
+                mudDrawer.classList.toggle('mud-drawer--closed');
+                mudDrawer.classList.remove('mud-drawer--initial');
+            }
+
+            const header = document.querySelector('.mud-drawer-header');
+
+            if (header) {
+                if (mudDrawer.className.includes('mud-drawer--closed') === true) {
+                    header.classList.add('mud-typography-nowrap');
+                }
+                else {
+                    header.classList.remove('mud-typography-nowrap');
+                }
+            }
+
+            const layout = mudDrawer.parentElement;
+
+            if (layout) {
+                if (layout.className.includes('mud-drawer-open') === true) {
+                    layout.className = layout.className.replace(/\bmud-drawer-open\b/g, 'mud-drawer-closed');
+                } else {
+                    layout.className = layout.className.replace(/\bmud-drawer-closed\b/g, 'mud-drawer-open');
+
+                    if (mudDrawer.className.includes('mud-static-responsive')) {
+                        mudDrawer.classList.add('mud-drawer-clipped-always');
+                    }
+                }
+            }
+        },
     };
 
     function ensureInitialized() {
         if (window.MutationObserverModule && !hasInitialized) {
             window.MutationObserverModule.initialize();
+            window.MudDrawerInterop.initialize();
         }
     }
 

--- a/tests/StaticInput.UnitTests.Viewer/Components/Layout/MainLayout.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Layout/MainLayout.razor
@@ -4,25 +4,34 @@
 
 <MudThemeProvider Theme="@customTheme" />
 
-<MudLayout>
-    <MudDrawer Open="true" Elevation="1" Breakpoint="Breakpoint.None" Fixed="true" Variant="DrawerVariant.Persistent">
-        <MudDrawerHeader>
-            <MudText Typo="Typo.h6">Static Input Tests</MudText>
-        </MudDrawerHeader>
-        <MudNavMenu>
-            @foreach (var type in _availableComponentTypes)
-            {
-                <MudNavLink @key="type.Name" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.List"
-                            Href="@Navigation.GetUriWithQueryParameter("Test", type.Name)">
-                    @type.Name
-                </MudNavLink>
-            }
-        </MudNavMenu>
-    </MudDrawer>
-    
-    <MudMainContent>
-        <MudContainer MaxWidth="MaxWidth.Medium">
-            <CascadingValue TValue="Type[]" IsFixed="true" Value="@_availableComponentTypes">
+<MudLayout Style="height:100vh">
+    <MudDrawerContainer>
+        <MudDrawer Open Fixed Elevation="1" Class="px-4" Style="width:auto"
+                   Breakpoint="Breakpoint.None" Variant="DrawerVariant.Persistent" ClipMode="DrawerClipMode.Docked">
+            <MudDrawerHeader>
+                <MudText Typo="Typo.h6">Static Input Tests</MudText>
+            </MudDrawerHeader>
+            <MudNavMenu>
+                @foreach (var component in _testComponents.Keys)
+                {
+                    <MudStaticNavGroup Title="@component">
+                       @foreach (var test in _testComponents[component])
+                        {
+                            <MudNavLink @key="test.Name" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.List"
+                                        Href="@Navigation.GetUriWithQueryParameter("Test", test.Name)">
+                                @test.Name
+                            </MudNavLink>
+                        }
+                    </MudStaticNavGroup>
+
+                }
+            </MudNavMenu>
+        </MudDrawer>
+    </MudDrawerContainer>
+
+    <MudMainContent Class="mud-height-full">
+        <MudContainer Class="mud-height-full" MaxWidth="MaxWidth.Medium">
+            <CascadingValue TValue="Dictionary<string, List<Type>>" IsFixed="true" Value="@_testComponents">
                 @Body
             </CascadingValue>
         </MudContainer>
@@ -38,11 +47,20 @@
         }
     };
 
-    private Type[] _availableComponentTypes = new Type[0];
-
+    private Dictionary<string, List<Type>> _testComponents = new();
+    
     protected override void OnInitialized()
     {
-        _availableComponentTypes = GetTestComponentTypes().ToArray();
+        var availableComponentTypes = GetTestComponentTypes().ToArray();
+
+
+        foreach (var item in availableComponentTypes)
+        {
+            var component = item.Namespace!.Split('.').Last();
+
+            if (!_testComponents.TryAdd(component, [item]))
+                _testComponents[component].Add(item);
+        }
 
         base.OnInitialized();
     }

--- a/tests/StaticInput.UnitTests.Viewer/Components/Layout/MainLayout.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Layout/MainLayout.razor
@@ -6,7 +6,7 @@
 
 <MudLayout Style="height:100vh">
     <MudDrawerContainer>
-        <MudDrawer Open Fixed Elevation="1" Class="px-4" Style="width:auto"
+        <MudDrawer Open Fixed Elevation="1" Class="@_class" Style="width:auto"
                    Breakpoint="Breakpoint.None" Variant="DrawerVariant.Persistent" ClipMode="DrawerClipMode.Docked">
             <MudDrawerHeader>
                 <MudText Typo="Typo.h6">Static Input Tests</MudText>
@@ -15,10 +15,10 @@
                 @foreach (var component in _testComponents.Keys)
                 {
                     <MudStaticNavGroup Title="@component">
-                       @foreach (var test in _testComponents[component])
+                        @foreach (var test in _testComponents[component])
                         {
                             <MudNavLink @key="test.Name" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.List"
-                                        Href="@Navigation.GetUriWithQueryParameter("Test", test.Name)">
+                            Href="@Navigation.GetUriWithQueryParameter("Test", test.Name)">
                                 @test.Name
                             </MudNavLink>
                         }
@@ -48,7 +48,8 @@
     };
 
     private Dictionary<string, List<Type>> _testComponents = new();
-    
+    private string _class = Environment.GetEnvironmentVariable("TEST_ENVIRONMENT")?.Equals("true") is true ? "d-none" : "px-4";
+
     protected override void OnInitialized()
     {
         var availableComponentTypes = GetTestComponentTypes().ToArray();

--- a/tests/StaticInput.UnitTests.Viewer/Components/Pages/Index.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Pages/Index.razor
@@ -20,7 +20,8 @@
     public string? TestComponent { get; set; } = null;
 
     [CascadingParameter]
-    public Type[] AvailableComponentTypes { get; set; } = [];
+    public Dictionary<string, List<Type>> TestComponents { get; set; } = new();
+
 
     private RenderFragment? RenderFragment { get; set; }
 
@@ -28,7 +29,7 @@
     {
         if (string.IsNullOrEmpty(TestComponent)) return;
 
-        var selectedType = AvailableComponentTypes.FirstOrDefault(type => type.Name.Contains(TestComponent, StringComparison.OrdinalIgnoreCase));
+        var selectedType = TestComponents.Values.SelectMany(x => x).FirstOrDefault(type => type.Name.Contains(TestComponent, StringComparison.OrdinalIgnoreCase));
 
         if (selectedType is null) return;
 

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/NavMenu/NavMenuCollapseExpandTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/NavMenu/NavMenuCollapseExpandTest.razor
@@ -1,0 +1,14 @@
+﻿<MudPaper Width="250px" Class="py-3" Elevation="0">
+    <MudText Typo="Typo.h6" Class="px-4">My Application</MudText>
+    <MudDivider Class="my-2" />
+    <MudNavMenu>
+        <MudNavLink Href="/dashboard">Dashboard</MudNavLink>
+        <MudNavLink Href="/servers">Servers</MudNavLink>
+        <MudNavLink Href="/billing" Disabled="true">Billing</MudNavLink>
+        <MudStaticNavGroup Title="Settings" Expanded="true">
+            <MudNavLink Href="/users">Users</MudNavLink>
+            <MudNavLink Href="/security">Security</MudNavLink>
+        </MudStaticNavGroup>
+        <MudNavLink Href="/about">About</MudNavLink>
+    </MudNavMenu>
+</MudPaper>

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/NavMenu/NavMenuDrawerToggleTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/NavMenu/NavMenuDrawerToggleTest.razor
@@ -1,0 +1,29 @@
+﻿<MudLayout>
+    <MudAppBar Elevation="1" Fixed="false">
+        <MudStaticNavDrawerToggle id="static-left-toggle" DrawerId="static-mini" Icon="@Icons.Material.Filled.KeyboardDoubleArrowRight" Color="Color.Inherit" Edge="Edge.Start" />
+        <MudSpacer />
+        <MudStaticNavDrawerToggle id="static-right-toggle" DrawerId="static-persistent" Icon="@Icons.Material.Filled.KeyboardDoubleArrowLeft" Color="Color.Inherit" Edge="Edge.End" />
+    </MudAppBar>
+    <MudPaper Class="d-flex justify-center" Style="height:200px; overflow:hidden; position:relative;">
+        <MudDrawer id="static-mini" Fixed="false" Elevation="1" Anchor="Anchor.Start" Variant="@DrawerVariant.Mini" ClipMode="DrawerClipMode.Always">
+            <MudNavMenu>
+                <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Store">Store</MudNavLink>
+                <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.LibraryBooks">Library</MudNavLink>
+                <MudNavLink Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Group">Community</MudNavLink>
+            </MudNavMenu>
+        </MudDrawer>
+        <MudAlert Class="absolute align-self-center" Severity="Severity.Success">Text inside MudContainer</MudAlert>
+        <MudDrawerContainer Class="mud-height-full" Style="overflow:hidden">
+            <MudDrawer id="static-persistent" Elevation="1" Anchor="Anchor.End" Variant="@DrawerVariant.Persistent" ClipMode="DrawerClipMode.Always">
+                <MudDrawerHeader>
+                    <MudText Typo="Typo.h6">Persistent</MudText>
+                </MudDrawerHeader>
+                <MudNavMenu>
+                    <MudNavLink Match="NavLinkMatch.All">Store</MudNavLink>
+                    <MudNavLink Match="NavLinkMatch.All">Library</MudNavLink>
+                    <MudNavLink Match="NavLinkMatch.All">Community</MudNavLink>
+                </MudNavMenu>
+            </MudDrawer>
+        </MudDrawerContainer>
+    </MudPaper>
+</MudLayout>

--- a/tests/StaticInput.UnitTests/Components/ButtonTests.cs
+++ b/tests/StaticInput.UnitTests/Components/ButtonTests.cs
@@ -2,6 +2,7 @@
 using Bunit.TestDoubles;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Playwright;
 using MudBlazor.StaticInput;
 using StaticInput.UnitTests.Fixtures;
 using StaticInput.UnitTests.Viewer.Components.Tests.Button;
@@ -110,7 +111,7 @@ namespace StaticInput.UnitTests.Components
             await input.FillAsync(email);
             await Expect(input).ToHaveValueAsync(email);
 
-            await Page.Locator("button").ClickAsync();
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Reset" }).ClickAsync();
 
             await Expect(input).ToBeEmptyAsync();
         }

--- a/tests/StaticInput.UnitTests/Components/CheckBoxTests.cs
+++ b/tests/StaticInput.UnitTests/Components/CheckBoxTests.cs
@@ -1,6 +1,7 @@
 ﻿using AngleSharp.Css.Dom;
 using Bunit;
 using FluentAssertions;
+using Microsoft.Playwright;
 using MudBlazor.StaticInput;
 using StaticInput.UnitTests.Fixtures;
 using StaticInput.UnitTests.Viewer.Components.Tests.CheckBox;
@@ -107,7 +108,7 @@ namespace StaticInput.UnitTests.Components
             await Page.GotoAsync(url);
 
             var checkbox = Page.Locator("input[type='checkbox']");
-            var button = Page.Locator("button");
+            var button = Page.GetByRole(AriaRole.Button, new() { Name = "Submit" });
 
             await Expect(checkbox).ToBeCheckedAsync(new() { Checked = false });
 

--- a/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
+++ b/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
@@ -13,8 +13,11 @@ namespace StaticInput.UnitTests.Components
 
             await Page.GotoAsync(url);
 
-            var button = Page.Locator("nav button");
-            var menuGroup = Page.Locator(".mud-collapse-container");
+            var button = Page.GetByLabel("Toggle Settings");
+            var menuGroup = Page.GetByLabel("Settings", new() { Exact = true })
+                                .Locator("div")
+                                .Filter(new() { HasText = "Users Security" })
+                                .First;
 
             var menuClasses = await menuGroup.GetAttributeAsync("class");
             var ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");

--- a/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
+++ b/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using StaticInput.UnitTests.Fixtures;
+using StaticInput.UnitTests.Viewer.Components.Tests.NavMenu;
+
+namespace StaticInput.UnitTests.Components
+{
+    public partial class NavMenuTests(ContextFixture contextFixture) : BaseComponentTest(contextFixture)
+    {
+        [Fact]
+        public async Task Group_Collapses_Expands_On_Click()
+        {
+            var url = typeof(NavMenuCollapseExpandTest).ToQueryString();
+
+            await Page.GotoAsync(url);
+
+            var button = Page.Locator("nav button");
+            var menuGroup = Page.Locator(".mud-collapse-container");
+
+            var menuClasses = await menuGroup.GetAttributeAsync("class");
+            var ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");
+
+            menuClasses.Should().NotBeNullOrEmpty();
+            menuClasses.Should().Contain("mud-collapse-entering");
+            ariaValue.Should().Be("false");
+
+            await button.ClickAsync();
+
+            menuClasses = await menuGroup.GetAttributeAsync("class");
+            menuClasses.Should().NotContain("mud-collapse-entered").And.NotContain("mud-collapse-entering");
+
+            ariaValue = await menuGroup.GetAttributeAsync("aria-hidden"); 
+            ariaValue.Should().Be("true");
+
+            await button.ClickAsync();
+
+            menuClasses = await menuGroup.GetAttributeAsync("class");
+            menuClasses.Should().Contain("mud-collapse-entered");
+
+            ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");
+            ariaValue.Should().Be("false");
+        }
+
+        [Fact]
+        public async Task Toggle_MudDrawer()
+        {
+            var url = typeof(NavMenuDrawerToggleTest).ToQueryString();
+
+            await Page.GotoAsync(url);
+
+            var leftToggle = Page.Locator("#static-left-toggle");
+            var rightToggle = Page.Locator("#static-right-toggle");
+            var miniDawer = Page.Locator("#static-mini");
+            var persistentDawer = Page.Locator("#static-persistent");
+
+            var miniClasses = await miniDawer.GetAttributeAsync("class");            
+            miniClasses.Should().NotBeNullOrEmpty();
+            miniClasses.Should().Contain("mud-drawer--closed");
+
+            var persistentClasses = await persistentDawer.GetAttributeAsync("class");
+            persistentClasses.Should().NotBeNullOrEmpty();
+            persistentClasses.Should().Contain("mud-drawer--closed");
+
+            await leftToggle.ClickAsync();
+            miniClasses = await miniDawer.GetAttributeAsync("class");
+            miniClasses.Should().Contain("mud-drawer--open");
+
+            await rightToggle.ClickAsync();
+            persistentClasses = await persistentDawer.GetAttributeAsync("class");
+            persistentClasses.Should().Contain("mud-drawer--open");
+
+            await rightToggle.ClickAsync();
+            persistentClasses = await persistentDawer.GetAttributeAsync("class");
+            persistentClasses.Should().Contain("mud-drawer--closed");
+
+            await leftToggle.ClickAsync();
+            miniClasses = await miniDawer.GetAttributeAsync("class");
+            miniClasses.Should().Contain("mud-drawer--closed");
+        }
+    }
+}

--- a/tests/StaticInput.UnitTests/Components/SwitchTests.cs
+++ b/tests/StaticInput.UnitTests/Components/SwitchTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Microsoft.Playwright;
 using MudBlazor.StaticInput;
 using StaticInput.UnitTests.Fixtures;
 using StaticInput.UnitTests.Viewer.Components.Tests.Switch;
@@ -98,7 +99,7 @@ namespace StaticInput.UnitTests.Components
             await Page.GotoAsync(url);
 
             var checkbox = Page.Locator("input[type='checkbox']");
-            var button = Page.Locator("button");
+            var button = Page.GetByRole(AriaRole.Button, new() { Name = "Submit" });
 
             await Expect(checkbox).ToBeCheckedAsync(new() { Checked = false });
 

--- a/tests/StaticInput.UnitTests/Components/TextFieldTests.cs
+++ b/tests/StaticInput.UnitTests/Components/TextFieldTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bunit;
 using FluentAssertions;
+using Microsoft.Playwright;
 using MudBlazor.StaticInput;
 using StaticInput.UnitTests.Fixtures;
 using StaticInput.UnitTests.Viewer.Components.Tests.TextField;
@@ -164,7 +165,7 @@ namespace StaticInput.UnitTests.Components
             await Page.GotoAsync(url);
 
             var field = Page.GetByLabel("Short string");
-            var button = Page.Locator("button");
+            var button = Page.GetByRole(AriaRole.Button, new() { Name = "Validate" });
 
             await button.ClickAsync();
 
@@ -212,7 +213,7 @@ namespace StaticInput.UnitTests.Components
 
             await Page.GotoAsync(url);
 
-            var button = Page.Locator("button");
+            var button = Page.GetByRole(AriaRole.Button);
             var message = string.Empty;
 
             Page.Dialog += async (_, dialog) =>

--- a/tests/StaticInput.UnitTests/TestSetup.cs
+++ b/tests/StaticInput.UnitTests/TestSetup.cs
@@ -18,11 +18,16 @@ namespace StaticInput.UnitTests
                 process.Kill();
             }
 
-            _testViewerProcess = Process.Start(new ProcessStartInfo()
+            var startInfo = new ProcessStartInfo()
             {
                 FileName = "dotnet",
                 Arguments = $"run --project {GetProjectPath()}"
-            });
+            };
+
+            startInfo.EnvironmentVariables.Add("TEST_ENVIRONMENT", "true");
+
+
+            _testViewerProcess = Process.Start(startInfo);
 
             messageSink.OnMessage(new DiagnosticMessage($"Started {_testViewerProcess?.ProcessName} with ID: {_testViewerProcess?.Id}"));
         }


### PR DESCRIPTION
## Description

This PR adds two new components that can be used when creating a nav menu. Each component is independent of each other with no implementation dependencies. 

- **MudStaticNavDrawerToggle**: An icon button used to toggle a `MudDrawer` open/closed
- **MudStaticNavGroup**: A collapsible group of nav menu items (e.g. `MudNavLink`)

> [!NOTE]  
> - The `MudStaticNavDrawerToggle` works with all `DrawerVariants` except for `Temporary` 
> - The drawer `ClipMode` should be set to `Always`  

Resolves #23 