### PR TITLE
Quick Fix - remove data-static-component attribute

### DIFF
--- a/src/Components/NavMenu/MudStaticNavDrawerToggle.razor
+++ b/src/Components/NavMenu/MudStaticNavDrawerToggle.razor
@@ -24,7 +24,6 @@
     protected override void OnParametersSet()
     {
         UserAttributes["data-mud-drawer-toggle"] = DrawerId;
-        UserAttributes["data-static-component"] = true;
         UserAttributes["data-static-id"] = _elementId;
 
         base.OnClick = EventCallback.Factory.Create<MouseEventArgs>(this, async () => await JsRuntime.InvokeVoidAsync("MudDrawerInterop.toggleDrawer", DrawerId));

--- a/src/Components/NavMenu/MudStaticNavGroup.razor
+++ b/src/Components/NavMenu/MudStaticNavGroup.razor
@@ -11,7 +11,6 @@
 
     protected override void OnParametersSet()
     {
-        UserAttributes["data-static-component"] = true;
         UserAttributes["data-static-id"] = _elementId;
 
         base.OnParametersSet();


### PR DESCRIPTION
As these components are meant to be nested within the layout, they do not require a refresh when navigating between static pages. 