### PR TITLE
MudStaticRadioGroup/MudStaticRadio: Initial implementation

### DIFF
--- a/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
+++ b/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Blazr.RenderState.WASM" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-	<PackageReference Include="MudBlazor" Version="8.2.0" />
+	<PackageReference Include="MudBlazor" Version="8.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.10" />
   </ItemGroup>
 

--- a/demo/StaticSample/StaticSample/StaticSample.csproj
+++ b/demo/StaticSample/StaticSample/StaticSample.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor" Version="8.2.0" />
+    <PackageReference Include="MudBlazor" Version="8.*" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Components/MudStaticRadio.razor
+++ b/src/Components/MudStaticRadio.razor
@@ -5,12 +5,15 @@
 
 <MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        <label class="@LabelClassname" style="@Style" id="@_elementId" @onclick:stopPropagation="@StopClickPropagation">
+        <label class="@LabelClassname" style="@Style" id="@($"static-radio-container-{_elementId}")" @onclick:stopPropagation="@StopClickPropagation">
             <span tabindex="0" class="@IconClassname">
                 <input id="@($"static-radio-{_elementId}")" tabindex="-1" @attributes="UserAttributes" type="radio" role="radio"
-                       class="mud-radio-input" checked="@IsChecked" name="@ParentGroup?.Name" disabled="@GetDisabledState()" value="@Value"
-                       aria-checked="@(IsChecked.ToString().ToLower())" aria-disabled="@(GetDisabledState().ToString().ToLower())" @onclick:preventDefault="@GetReadOnlyState()" />
-                <MudIcon id="@($"radio-svg-{_elementId}")" Disabled="@Disabled" Icon="@(IsChecked ? CheckedIcon : UncheckedIcon)" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
+                       class="mud-radio-input static-radio-input" checked="@_isChecked" disabled="@GetDisabledState()" name="@(_isChecked ? ParentGroup?.GroupName : "")" value="@Value"
+                       aria-checked="@(_isChecked.ToString().ToLower())" aria-disabled="@(GetDisabledState().ToString().ToLower())" @onclick:preventDefault="@GetReadOnlyState()" />
+                <MudIcon Icon="@CheckedIcon" Color="HasErrors ? Color.Error : this.Color" Size="@Size" Disabled="@Disabled"
+                         id="@($"radio-checked-icon-{_elementId}")" style="@($"display: {_checkedStyle}")" />
+                <MudIcon Icon="@UncheckedIcon" Color="HasErrors ? Color.Error : this.UncheckedColor ?? Color.Inherit" Size="@Size" Disabled="@Disabled"
+                         id="@($"radio-unchecked-icon-{_elementId}")" style="@($"display: {_uncheckedStyle}")" />
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {
@@ -30,27 +33,27 @@
     [CascadingParameter]
     private MudStaticRadioGroup<T>? ParentGroup { get; set; }
 
-    private bool IsChecked => ParentGroup is not null && EqualityComparer<T>.Default.Equals(ParentGroup.Value, Value);
+    [Parameter]
+    public Expression<Func<T?>>? ValueExpression { get; set; }
 
+    private bool _isChecked;
     private readonly string _elementId = Guid.NewGuid().ToString()[..8];
+    private string _checkedStyle => _isChecked ? "block" : "none";
+    private string _uncheckedStyle => _isChecked ? "none" : "block";
 
     protected override void OnInitialized()
     {
         if (ParentGroup is null)
-        {
             throw new InvalidOperationException($"{nameof(MudStaticRadio<T>)} must be used inside a {nameof(MudStaticRadioGroup<T>)}");
-        }
+
+        if (ParentGroup!.SelectedValue is not null)
+            _isChecked = ParentGroup!.SelectedValue!.Equals(Value);
 
         base.OnInitialized();
     }
 
     protected override void OnParametersSet()
     {
-        if (UserAttributes is null)
-        {
-            UserAttributes = new Dictionary<string, object?>();
-        }
-
         UserAttributes["data-static-component"] = true;
 
         base.OnParametersSet();
@@ -58,25 +61,36 @@
 }
 
 <script>
-    (function() {
-        const radio = document.getElementById('static-radio-@_elementId');
-        const svg = document.getElementById('radio-svg-@_elementId');
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll('.static-radio-input').forEach(function (radio) {
+            radio.addEventListener('change', function () {
+                const parentContainer = radio.closest("[role='radiogroup']");
+                if (!parentContainer) return;
 
-        const checkedIcon = '@(CheckedIcon)';
-        const uncheckedIcon = '@(UncheckedIcon)';
+                parentContainer.querySelectorAll('.static-radio-input').forEach(function (r) {
+                    if (r !== radio) {
+                        r.checked = false;
+                        r.removeAttribute("name");
+                        r.setAttribute("checked", false);
+                        r.setAttribute("aria-checked", false);
+                    }
 
-        if (radio && svg) {
-            const handleChange = () => {
-                svg.innerHTML = radio.checked ? checkedIcon : uncheckedIcon;
-            };
+                    const radioId = r.id.split('-')[2];
+                    const checkedIcon = document.getElementById(`radio-checked-icon-${radioId}`);
+                    const uncheckedIcon = document.getElementById(`radio-unchecked-icon-${radioId}`);
 
-            radio.addEventListener('change', handleChange);
-
-            document.addEventListener('change', (e) => {
-                if (e.target.type === 'radio' && e.target.name === radio.name && e.target !== radio) {
-                    handleChange();
-                }
+                    if (r.checked) {
+                        checkedIcon.style.display = 'block';
+                        uncheckedIcon.style.display = 'none';
+                        r.setAttribute("checked", true);
+                        r.setAttribute("aria-checked", true);
+                        r.setAttribute("name", "@ParentGroup?.GroupName");
+                    } else {
+                        checkedIcon.style.display = 'none';
+                        uncheckedIcon.style.display = 'block';
+                    }
+                });
             });
-        }
-    })();
+        });
+    });
 </script>

--- a/src/Components/MudStaticRadio.razor
+++ b/src/Components/MudStaticRadio.razor
@@ -18,14 +18,10 @@
                        id="@($"static-radio-{_elementId}")"
                        checked="@IsChecked" />
 
-                <svg class="mud-icon-root mud-svg-icon mud-icon-size-medium"
-                     focusable="false"
-                     viewBox="0 0 24 24"
-                     aria-hidden="true"
-                     role="img"
-                     id="@($"radio-svg-{_elementId}")">
-                    @(new MarkupString(IsChecked ? Icons.Material.Filled.RadioButtonChecked : Icons.Material.Filled.RadioButtonUnchecked))
-                </svg>
+                <MudIcon Size="Size"
+                         Color="HasErrors ? Color.Error : Color"
+                         Icon="@(IsChecked ? CheckedIcon : UncheckedIcon)"
+                         id="@($"radio-svg-{_elementId}")" />
             </span>
 
             <p class="mud-typography mud-typography-body1">
@@ -40,8 +36,8 @@
         const radio = document.getElementById('static-radio-@_elementId');
         const svg = document.getElementById('radio-svg-@_elementId');
 
-        const checkedIcon = '@(Icons.Material.Filled.RadioButtonChecked)';
-        const uncheckedIcon = '@(Icons.Material.Filled.RadioButtonUnchecked)';
+        const checkedIcon = '@(CheckedIcon)';
+        const uncheckedIcon = '@(UncheckedIcon)';
 
         if (radio && svg) {
             const handleChange = () => {
@@ -65,9 +61,6 @@
 
     private bool IsChecked => ParentGroup is not null && EqualityComparer<T>.Default.Equals(ParentGroup.Value, Value);
 
-    private const string UnChecked = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z";
-    private const string Checked = "M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z";
-
     private readonly string _elementId = Guid.NewGuid().ToString()[..8];
 
     protected override void OnInitialized()
@@ -76,8 +69,6 @@
         {
             throw new InvalidOperationException($"{nameof(MudStaticRadio<T>)} must be used inside a {nameof(MudStaticRadioGroup<T>)}");
         }
-
-        var test = Icons.Material.Filled.RadioButtonChecked;
 
         base.OnInitialized();
     }

--- a/src/Components/MudStaticRadio.razor
+++ b/src/Components/MudStaticRadio.razor
@@ -10,10 +10,10 @@
                 <input id="@($"static-radio-{_elementId}")" tabindex="-1" @attributes="UserAttributes" type="radio" role="radio"
                        class="mud-radio-input static-radio-input" checked="@_isChecked" disabled="@GetDisabledState()" name="@(_isChecked ? ParentGroup?.GroupName : "")" value="@Value"
                        aria-checked="@(_isChecked.ToString().ToLower())" aria-disabled="@(GetDisabledState().ToString().ToLower())" @onclick:preventDefault="@GetReadOnlyState()" />
-                <MudIcon Icon="@CheckedIcon" Color="HasErrors ? Color.Error : this.Color" Size="@Size" Disabled="@Disabled"
+                <MudIcon Icon="@(ParentGroup.CheckedIcon ?? CheckedIcon)" Color="HasErrors ? Color.Error : ParentGroup?.Color ?? this.Color" Size="@Size" Disabled="@Disabled"
                          id="@($"radio-checked-icon-{_elementId}")" style="@($"display: {_checkedStyle}")" />
-                <MudIcon Icon="@UncheckedIcon" Color="HasErrors ? Color.Error : this.UncheckedColor ?? Color.Inherit" Size="@Size" Disabled="@Disabled"
-                         id="@($"radio-unchecked-icon-{_elementId}")" style="@($"display: {_uncheckedStyle}")" />
+                <MudIcon Icon="@(ParentGroup.UncheckedIcon ?? UncheckedIcon)" Color="HasErrors ? Color.Error : ParentGroup?.UncheckedColor ?? this.UncheckedColor ?? Color.Inherit" 
+                         Size="@Size" Disabled="@Disabled" id="@($"radio-unchecked-icon-{_elementId}")" style="@($"display: {_uncheckedStyle}")" />
             </span>
             @if (!string.IsNullOrEmpty(Label))
             {

--- a/src/Components/MudStaticRadio.razor
+++ b/src/Components/MudStaticRadio.razor
@@ -1,0 +1,104 @@
+﻿@namespace MudBlazor.StaticInput
+
+@typeparam T
+@inherits MudRadio<T>
+
+<div class="mud-input-control mud-input-control-boolean-input mud-input-with-content">
+    <div class="mud-input-control-input-container">
+        <label class="mud-radio mud-input-content-placement-end" __internal_stoppropagation_onclick="">
+            <span class="mud-button-root mud-icon-button mud-ripple mud-ripple-radio mud-default-text hover:mud-default-hover"
+                  tabindex="0"
+                  @onclick:stopPropagation="true">
+                <input type="radio"
+                       class="mud-radio-input"
+                       tabindex="-1"
+                       role="radio"
+                       name="@ParentGroup?.GroupName"
+                       value="@Value"
+                       id="@($"static-radio-{_elementId}")"
+                       checked="@IsChecked" />
+
+                <svg class="mud-icon-root mud-svg-icon mud-icon-size-medium"
+                     focusable="false"
+                     viewBox="0 0 24 24"
+                     aria-hidden="true"
+                     role="img"
+                     id="@($"radio-svg-{_elementId}")">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path d="@(IsChecked ? Checked : UnChecked)"></path>
+                </svg>
+            </span>
+
+            <p class="mud-typography mud-typography-body1">
+                @ChildContent
+            </p>
+        </label>
+    </div>
+</div>
+
+<script>
+    (function() {
+        const radio = document.getElementById('static-radio-@_elementId');
+        const svg = document.getElementById('radio-svg-@_elementId');
+
+        if (radio && svg) {
+            const handleChange = () => {
+                const path = svg.querySelector('path:last-child');
+
+                if (path) {
+                    path.setAttribute('d', radio.checked ? '@Checked' : '@UnChecked');
+                }
+            };
+
+            radio.addEventListener('change', handleChange);
+
+            document.addEventListener('change', (e) => {
+                if (e.target.type === 'radio' && e.target.name === radio.name && e.target !== radio) {
+                    handleChange();
+                }
+            });
+        }
+    })();
+</script>
+
+@code {
+    [CascadingParameter]
+    private MudStaticRadioGroup<T>? ParentGroup { get; set; }
+
+    private bool IsChecked => ParentGroup is not null && EqualityComparer<T>.Default.Equals(ParentGroup.Value, Value);
+
+    private const string UnChecked = "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z";
+    private const string Checked = "M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zm0-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z";
+
+    private readonly string _elementId = Guid.NewGuid().ToString()[..8];
+
+    protected override void OnInitialized()
+    {
+        if (ParentGroup is null)
+        {
+            throw new InvalidOperationException($"{nameof(MudStaticRadio<T>)} must be used inside a {nameof(MudStaticRadioGroup<T>)}");
+        }
+
+        base.OnInitialized();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (UserAttributes is null)
+        {
+            UserAttributes = new Dictionary<string, object?>();
+        }
+
+        UserAttributes["data-static-component"] = true;
+
+        base.OnParametersSet();
+    }
+
+    private async Task SelectValue()
+    {
+        if (ParentGroup is not null)
+        {
+            await ParentGroup.SetValue(Value);
+        }
+    }
+}

--- a/src/Components/MudStaticRadio.razor
+++ b/src/Components/MudStaticRadio.razor
@@ -3,57 +3,28 @@
 @typeparam T
 @inherits MudRadio<T>
 
-<div class="mud-input-control mud-input-control-boolean-input mud-input-with-content">
-    <div class="mud-input-control-input-container">
-        <label class="mud-radio mud-input-content-placement-end" __internal_stoppropagation_onclick="">
-            <span class="mud-button-root mud-icon-button mud-ripple mud-ripple-radio mud-default-text hover:mud-default-hover"
-                  tabindex="0"
-                  @onclick:stopPropagation="true">
-                <input type="radio"
-                       class="mud-radio-input"
-                       tabindex="-1"
-                       role="radio"
-                       name="@ParentGroup?.GroupName"
-                       value="@Value"
-                       id="@($"static-radio-{_elementId}")"
-                       checked="@IsChecked" />
-
-                <MudIcon Size="Size"
-                         Color="HasErrors ? Color.Error : Color"
-                         Icon="@(IsChecked ? CheckedIcon : UncheckedIcon)"
-                         id="@($"radio-svg-{_elementId}")" />
+<MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
+    <InputContent>
+        <label class="@LabelClassname" style="@Style" id="@_elementId" @onclick:stopPropagation="@StopClickPropagation">
+            <span tabindex="0" class="@IconClassname">
+                <input id="@($"static-radio-{_elementId}")" tabindex="-1" @attributes="UserAttributes" type="radio" role="radio"
+                       class="mud-radio-input" checked="@IsChecked" name="@ParentGroup?.Name" disabled="@GetDisabledState()" value="@Value"
+                       aria-checked="@(IsChecked.ToString().ToLower())" aria-disabled="@(GetDisabledState().ToString().ToLower())" @onclick:preventDefault="@GetReadOnlyState()" />
+                <MudIcon id="@($"radio-svg-{_elementId}")" Disabled="@Disabled" Icon="@(IsChecked ? CheckedIcon : UncheckedIcon)" Color="HasErrors ? Color.Error : Color.Inherit" Size="@Size" />
             </span>
-
-            <p class="mud-typography mud-typography-body1">
-                @ChildContent
-            </p>
+            @if (!string.IsNullOrEmpty(Label))
+            {
+                <MudText Color="HasErrors ? Color.Error : Color.Inherit">@Label</MudText>
+            }
+            @if (ChildContent is not null)
+            {
+                <MudText Color="HasErrors ? Color.Error : Color.Inherit">
+                    @ChildContent
+                </MudText>
+            }
         </label>
-    </div>
-</div>
-
-<script>
-    (function() {
-        const radio = document.getElementById('static-radio-@_elementId');
-        const svg = document.getElementById('radio-svg-@_elementId');
-
-        const checkedIcon = '@(CheckedIcon)';
-        const uncheckedIcon = '@(UncheckedIcon)';
-
-        if (radio && svg) {
-            const handleChange = () => {
-                svg.innerHTML = radio.checked ? checkedIcon : uncheckedIcon;
-            };
-
-            radio.addEventListener('change', handleChange);
-
-            document.addEventListener('change', (e) => {
-                if (e.target.type === 'radio' && e.target.name === radio.name && e.target !== radio) {
-                    handleChange();
-                }
-            });
-        }
-    })();
-</script>
+    </InputContent>
+</MudInputControl>
 
 @code {
     [CascadingParameter]
@@ -84,12 +55,28 @@
 
         base.OnParametersSet();
     }
-
-    private async Task SelectValue()
-    {
-        if (ParentGroup is not null)
-        {
-            await ParentGroup.SetValue(Value);
-        }
-    }
 }
+
+<script>
+    (function() {
+        const radio = document.getElementById('static-radio-@_elementId');
+        const svg = document.getElementById('radio-svg-@_elementId');
+
+        const checkedIcon = '@(CheckedIcon)';
+        const uncheckedIcon = '@(UncheckedIcon)';
+
+        if (radio && svg) {
+            const handleChange = () => {
+                svg.innerHTML = radio.checked ? checkedIcon : uncheckedIcon;
+            };
+
+            radio.addEventListener('change', handleChange);
+
+            document.addEventListener('change', (e) => {
+                if (e.target.type === 'radio' && e.target.name === radio.name && e.target !== radio) {
+                    handleChange();
+                }
+            });
+        }
+    })();
+</script>

--- a/src/Components/MudStaticRadio.razor
+++ b/src/Components/MudStaticRadio.razor
@@ -24,8 +24,7 @@
                      aria-hidden="true"
                      role="img"
                      id="@($"radio-svg-{_elementId}")">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path d="@(IsChecked ? Checked : UnChecked)"></path>
+                    @(new MarkupString(IsChecked ? Icons.Material.Filled.RadioButtonChecked : Icons.Material.Filled.RadioButtonUnchecked))
                 </svg>
             </span>
 
@@ -41,13 +40,12 @@
         const radio = document.getElementById('static-radio-@_elementId');
         const svg = document.getElementById('radio-svg-@_elementId');
 
+        const checkedIcon = '@(Icons.Material.Filled.RadioButtonChecked)';
+        const uncheckedIcon = '@(Icons.Material.Filled.RadioButtonUnchecked)';
+
         if (radio && svg) {
             const handleChange = () => {
-                const path = svg.querySelector('path:last-child');
-
-                if (path) {
-                    path.setAttribute('d', radio.checked ? '@Checked' : '@UnChecked');
-                }
+                svg.innerHTML = radio.checked ? checkedIcon : uncheckedIcon;
             };
 
             radio.addEventListener('change', handleChange);
@@ -78,6 +76,8 @@
         {
             throw new InvalidOperationException($"{nameof(MudStaticRadio<T>)} must be used inside a {nameof(MudStaticRadioGroup<T>)}");
         }
+
+        var test = Icons.Material.Filled.RadioButtonChecked;
 
         base.OnInitialized();
     }

--- a/src/Components/MudStaticRadioGroup.razor
+++ b/src/Components/MudStaticRadioGroup.razor
@@ -33,6 +33,30 @@
     [Parameter] 
     public Expression<Func<T?>>? ValueExpression { get; set; }
 
+    /// <summary>
+    /// The color to use when in an checked state
+    /// </summary>
+    [Parameter]
+    public Color? Color { get; set; }
+
+    /// <summary>
+    /// The color to use when in an unchecked state
+    /// </summary>
+    [Parameter]
+    public Color? UncheckedColor { get; set; }
+
+    // /// <summary>
+    // ///     The icon displayed when in a checked state.
+    // /// </summary>
+    [Parameter]
+    public string? CheckedIcon { get; set; }
+
+    // /// <summary>
+    // ///     The icon displayed when in an unchecked state.
+    // /// </summary>
+    [Parameter]
+    public string? UncheckedIcon { get; set; }
+
     public string GroupName { get; set; } = string.Empty;
     public T? SelectedValue { get; set; }
 

--- a/src/Components/MudStaticRadioGroup.razor
+++ b/src/Components/MudStaticRadioGroup.razor
@@ -10,8 +10,10 @@
             <CascadingValue TValue="IForm" Value="null">
                 <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
                     <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
-                        <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" required="@Required" 
-                             aria-required="@Required.ToString().ToLowerInvariant()">
+                        <div id="@($"static-radio-group-{_elementId}")" role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" 
+                             style="@InputStyle" required="@Required" aria-required="@Required.ToString().ToLowerInvariant()">
+                            <input type="hidden" id="@($"empty-radio-{_elementId}")" name="@(_valueSelected ? "" : GroupName)" value="@SelectedValue" />
+
                             @ChildContent
                         </div>
                     </CascadingValue>
@@ -28,26 +30,31 @@
     [CascadingParameter(Name = "ParentReadOnly")]
     private bool ParentIsReadOnly { get; set; }
 
-    [Parameter]
+    [Parameter] 
     public Expression<Func<T?>>? ValueExpression { get; set; }
 
-    public string GroupName { get; private set; } = Guid.NewGuid().ToString();
+    public string GroupName { get; set; } = string.Empty;
+    public T? SelectedValue { get; set; }
+
+    private bool _valueSelected;
+    private readonly string _elementId = Guid.NewGuid().ToString()[..8];
 
     protected override void OnInitialized()
     {
-        if (For is not null)
+        if (ValueExpression is not null)
         {
-            string expression = For.ToString();
-            int index = expression.LastIndexOf(").", StringComparison.Ordinal);
+            var expression = ValueExpression.ToString();
+            var index = expression.LastIndexOf(").", StringComparison.Ordinal);
 
             if (index > 0)
             {
                 GroupName = expression[(index + 2)..];
             }
-        }
-        else
-        {
-            GroupName = Guid.NewGuid().ToString();
+
+            var compiledExpression = ValueExpression!.Compile();
+
+            SelectedValue = compiledExpression();
+            _valueSelected = SelectedValue is not null;
         }
 
         base.OnInitialized();

--- a/src/Components/MudStaticRadioGroup.razor
+++ b/src/Components/MudStaticRadioGroup.razor
@@ -1,0 +1,61 @@
+﻿@namespace MudBlazor.StaticInput
+
+@typeparam T
+@inherits MudRadioGroup<T>
+
+<MudInputControl Class="@Classname"
+                 Style="@Style"
+                 Error="@HasErrors"
+                 ErrorText="@GetErrorText()"
+                 Required="@Required">
+    <InputContent>
+        <CascadingValue Value="this">
+            <div class="mud-input-control mud-input-control-boolean-input">
+                <div class="mud-input-control-input-container">
+                    <div class="mud-radio-group" role="radiogroup">
+                        @ChildContent
+                    </div>
+                </div>
+            </div>
+        </CascadingValue>
+    </InputContent>
+</MudInputControl>
+
+@code {
+    [Parameter]
+    public Expression<Func<T?>>? ValueExpression { get; set; }
+
+    public string GroupName { get; private set; } = Guid.NewGuid().ToString();
+
+    protected override void OnInitialized()
+    {
+        if (For != null)
+        {
+            string expression = For.ToString();
+            int index = expression.LastIndexOf(").", StringComparison.Ordinal);
+
+            if (index > 0)
+            {
+                GroupName = expression[(index + 2)..];
+            }
+        }
+        else
+        {
+            GroupName = Guid.NewGuid().ToString();
+        }
+
+        base.OnInitialized();
+    }
+
+    internal async Task SetValue(T? newValue)
+    {
+        if (Value?.Equals(newValue) != true)
+        {
+            Value = newValue;
+
+            await ValueChanged.InvokeAsync(newValue);
+
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/MudStaticRadioGroup.razor
+++ b/src/Components/MudStaticRadioGroup.razor
@@ -1,27 +1,33 @@
 ﻿@namespace MudBlazor.StaticInput
+@using MudBlazor.Interfaces
 
 @typeparam T
 @inherits MudRadioGroup<T>
 
-<MudInputControl Class="@Classname"
-                 Style="@Style"
-                 Error="@HasErrors"
-                 ErrorText="@GetErrorText()"
-                 Required="@Required">
+<MudInputControl Class="@Classname" Style="@Style" Error="@HasErrors" ErrorText="@GetErrorText()" Required="@Required">
     <InputContent>
-        <CascadingValue Value="this">
-            <div class="mud-input-control mud-input-control-boolean-input">
-                <div class="mud-input-control-input-container">
-                    <div class="mud-radio-group" role="radiogroup">
-                        @ChildContent
-                    </div>
-                </div>
-            </div>
+        <CascadingValue Value="this" IsFixed="false">
+            <CascadingValue TValue="IForm" Value="null">
+                <CascadingValue TValue="bool" Name="ParentDisabled" Value="@GetDisabledState()">
+                    <CascadingValue TValue="bool" Name="ParentReadOnly" Value="@GetReadOnlyState()">
+                        <div role="radiogroup" @attributes="UserAttributes" class="@GetInputClass()" style="@InputStyle" required="@Required" 
+                             aria-required="@Required.ToString().ToLowerInvariant()">
+                            @ChildContent
+                        </div>
+                    </CascadingValue>
+                </CascadingValue>
+            </CascadingValue>
         </CascadingValue>
     </InputContent>
 </MudInputControl>
 
 @code {
+    [CascadingParameter(Name = "ParentDisabled")]
+    private bool ParentIsDisabled { get; set; }
+
+    [CascadingParameter(Name = "ParentReadOnly")]
+    private bool ParentIsReadOnly { get; set; }
+
     [Parameter]
     public Expression<Func<T?>>? ValueExpression { get; set; }
 
@@ -29,7 +35,7 @@
 
     protected override void OnInitialized()
     {
-        if (For != null)
+        if (For is not null)
         {
             string expression = For.ToString();
             int index = expression.LastIndexOf(").", StringComparison.Ordinal);
@@ -45,17 +51,5 @@
         }
 
         base.OnInitialized();
-    }
-
-    internal async Task SetValue(T? newValue)
-    {
-        if (Value?.Equals(newValue) != true)
-        {
-            Value = newValue;
-
-            await ValueChanged.InvokeAsync(newValue);
-
-            StateHasChanged();
-        }
     }
 }

--- a/src/Components/MudStaticRadioGroup.razor.cs
+++ b/src/Components/MudStaticRadioGroup.razor.cs
@@ -1,14 +1,22 @@
 using Microsoft.AspNetCore.Components;
+using MudBlazor.Utilities;
 
-namespace MudBlazor.StaticInput
+namespace MudBlazor.StaticInput;
+
+public partial class MudStaticRadioGroup<T> : MudRadioGroup<T>
 {
-    public partial class MudStaticRadioGroup<T> : MudRadioGroup<T>
-    {
-        /**********************************************
-         * Hide these inherited properties to prevent *
-         * consumers from modifying them directly.    *
-         **********************************************/
-        protected new T? Value { get; set; }
-        protected new EventCallback<T?> ValueChanged { get; set; }
-    }
+    /**********************************************
+     * Hide these inherited properties to prevent *
+     * consumers from modifying them directly.    *
+     **********************************************/
+    protected new T? Value { get; set; }
+    protected new EventCallback<T?> ValueChanged { get; set; }
+
+    private string GetInputClass() =>
+            new CssBuilder("mud-radio-group")
+                .AddClass(InputClass)
+                .Build();
+
+    internal bool GetDisabledState() => Disabled || ParentIsDisabled;
+    internal bool GetReadOnlyState() => ReadOnly || ParentIsReadOnly;
 }

--- a/src/Components/MudStaticRadioGroup.razor.cs
+++ b/src/Components/MudStaticRadioGroup.razor.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Components;
+
+namespace MudBlazor.StaticInput
+{
+    public partial class MudStaticRadioGroup<T> : MudRadioGroup<T>
+    {
+        /**********************************************
+         * Hide these inherited properties to prevent *
+         * consumers from modifying them directly.    *
+         **********************************************/
+        protected new T? Value { get; set; }
+        protected new EventCallback<T?> ValueChanged { get; set; }
+    }
+}

--- a/src/MudBlazor.StaticInput.csproj
+++ b/src/MudBlazor.StaticInput.csproj
@@ -22,7 +22,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
-        <PackageReference Include="MudBlazor" Version="8.2.0" />
+        <PackageReference Include="MudBlazor" Version="8.*" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioColorsTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioColorsTest.razor
@@ -1,0 +1,30 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+@inject NavigationManager NavigationManager
+
+<EditForm Model="Input" method="post" OnValidSubmit="OnValidSubmit" FormName="confirm">
+    <DataAnnotationsValidator />
+    <MudStack Row="true" AlignItems="AlignItems.Center">
+        <MudStaticRadioGroup @bind-Value="Input.SelectedValue" For="() => Input.SelectedValue">
+            <MudStaticRadio T="string" Value="@("A")" Color="Color.Primary" UncheckedColor="Color.Error" Size="Size.Medium">
+                Option A
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("B")" Color="Color.Primary" UncheckedColor="Color.Info" Size="Size.Medium">
+                Option B
+            </MudStaticRadio>
+        </MudStaticRadioGroup>
+        <MudStaticButton FormAction="FormAction.Submit" Color="Color.Primary" Variant="Variant.Filled">Submit</MudStaticButton>
+    </MudStack>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private InputModel Input { get; set; } = new();
+
+    private void OnValidSubmit() => NavigationManager.NavigateTo("");
+
+    private sealed class InputModel
+    {
+        public string? SelectedValue { get; set; }
+    }
+}

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioDisabledTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioDisabledTest.razor
@@ -1,0 +1,33 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+@inject NavigationManager NavigationManager
+
+<EditForm Model="Input" method="post" OnValidSubmit="OnValidSubmit" FormName="confirm">
+    <DataAnnotationsValidator />
+    <MudStack Row="true" AlignItems="AlignItems.Center">
+        <MudStaticRadioGroup @bind-Value="Input.SelectedValue" For="() => Input.SelectedValue" Color="Color.Primary">
+            <MudStaticRadio T="string" Value="@("A")" Size="Size.Medium">
+                Option A
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("B")" Size="Size.Medium" Disabled>
+                Option B
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("C")" Size="Size.Medium">
+                Option C
+            </MudStaticRadio>
+        </MudStaticRadioGroup>
+        <MudStaticButton FormAction="FormAction.Submit" Color="Color.Primary" Variant="Variant.Filled">Submit</MudStaticButton>
+    </MudStack>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private InputModel Input { get; set; } = new();
+
+    private void OnValidSubmit() => NavigationManager.NavigateTo("");
+
+    private sealed class InputModel
+    {
+        public string? SelectedValue { get; set; }
+    }
+}

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioGroupTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioGroupTest.razor
@@ -1,0 +1,13 @@
+﻿<MudStaticRadioGroup @bind-Value="SelectedValue">
+    <MudStaticRadio Value="@("A")">
+        Option A
+    </MudStaticRadio>
+
+    <MudStaticRadio Value="@("B")">
+        Option B
+    </MudStaticRadio>
+</MudStaticRadioGroup>
+
+@code {
+    private string SelectedValue { get; set; } = "A";
+}

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioIconTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioIconTest.razor
@@ -1,0 +1,13 @@
+﻿<MudStaticRadioGroup @bind-Value="SelectedValue" CheckedIcon="@Icons.Material.Filled.CheckBox" UncheckedIcon="@Icons.Material.Filled.CheckBoxOutlineBlank">
+    <MudStaticRadio Value="@("A")">
+        Option A
+    </MudStaticRadio>
+
+    <MudStaticRadio Value="@("B")">
+        Option B
+    </MudStaticRadio>
+</MudStaticRadioGroup>
+
+@code {
+    private string SelectedValue { get; set; } = "A";
+}

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioInitTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioInitTest.razor
@@ -1,0 +1,40 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+@inject NavigationManager NavigationManager
+
+<EditForm Model="Input" method="post" OnValidSubmit="OnValidSubmit" FormName="confirm">
+    <DataAnnotationsValidator />
+    <MudStack Row="true" AlignItems="AlignItems.Center">
+        <MudStaticRadioGroup @bind-Value="Input.SelectedValue" For="() => Input.SelectedValue" Color="Color.Primary" UncheckedColor="Color.Secondary">
+            <MudStaticRadio T="string" Value="@("A")" Size="Size.Medium">
+                Option A
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("B")" Size="Size.Medium">
+                Option B
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("C")" Size="Size.Medium">
+                Option C
+            </MudStaticRadio>
+        </MudStaticRadioGroup>
+        <MudStaticButton FormAction="FormAction.Submit" Color="Color.Primary" Variant="Variant.Filled">Submit</MudStaticButton>
+    </MudStack>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private InputModel Input { get; set; } = new();
+
+    private void OnValidSubmit() => NavigationManager.NavigateTo("");
+
+    protected override void OnInitialized()
+    {
+        Input.SelectedValue = "C";
+
+        base.OnInitialized();
+    }
+
+    private sealed class InputModel
+    {
+        public string? SelectedValue { get; set; }
+    }
+}

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioRequiredTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioRequiredTest.razor
@@ -1,0 +1,34 @@
+﻿@using System.ComponentModel.DataAnnotations
+
+@inject NavigationManager NavigationManager
+
+<EditForm Model="Input" method="post" OnValidSubmit="OnValidSubmit" FormName="confirm">
+    <DataAnnotationsValidator />
+    <MudStack Row="true" AlignItems="AlignItems.Center">
+        <MudStaticRadioGroup @bind-Value="Input.SelectedValue" For="() => Input.SelectedValue" Color="Color.Primary">
+            <MudStaticRadio T="string" Value="@("A")" Size="Size.Medium">
+                Option A
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("B")" Size="Size.Medium">
+                Option B
+            </MudStaticRadio>
+            <MudStaticRadio T="string" Value="@("C")" Size="Size.Medium">
+                Option C
+            </MudStaticRadio>
+        </MudStaticRadioGroup>
+        <MudStaticButton FormAction="FormAction.Submit" Color="Color.Primary" Variant="Variant.Filled">Submit</MudStaticButton>
+    </MudStack>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private InputModel Input { get; set; } = new();
+
+    private void OnValidSubmit() => NavigationManager.NavigateTo("");
+
+    private sealed class InputModel
+    {
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Selection required!")]
+        public string? SelectedValue { get; set; }
+    }
+}

--- a/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioSingleTest.razor
+++ b/tests/StaticInput.UnitTests.Viewer/Components/Tests/Radio/RadioSingleTest.razor
@@ -1,0 +1,9 @@
+﻿<MudStaticRadioGroup T="string" @bind-Value="SelectedValue">
+    <MudStaticRadio Value="@("A")">
+        Option A
+    </MudStaticRadio>
+</MudStaticRadioGroup>
+
+@code {
+    private string SelectedValue { get; set; } = "A";
+}

--- a/tests/StaticInput.UnitTests.Viewer/StaticInput.UnitTests.Viewer.csproj
+++ b/tests/StaticInput.UnitTests.Viewer/StaticInput.UnitTests.Viewer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="8.2.0" />
+    <PackageReference Include="MudBlazor" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/StaticInput.UnitTests/Components/RadioTests.cs
+++ b/tests/StaticInput.UnitTests/Components/RadioTests.cs
@@ -1,6 +1,4 @@
 ﻿using FluentAssertions;
-using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Components;
 using MudBlazor.StaticInput;
 using StaticInput.UnitTests.Fixtures;
 using Bunit;
@@ -61,11 +59,11 @@ namespace StaticInput.UnitTests.Components
             IElement? iconA = radioA.ParentElement.QuerySelector(".mud-icon-root");
             IElement? iconB = radioB.ParentElement.QuerySelector(".mud-icon-root");
 
-            iconA.Should().NotBeNull("L'icône de la radio A doit être rendue.");
-            iconB.Should().NotBeNull("L'icône de la radio B doit être rendue.");
+            iconA.Should().NotBeNull("The A radio input should be rendered.");
+            iconB.Should().NotBeNull("The B radio input should be rendered.");
 
-            iconA.InnerHtml.Should().Contain("M12 7c-2.76", "car la radio A est cochée");
-            iconB.InnerHtml.Should().Contain("M12 2C6.48", "car la radio B est décochée");
+            iconA.InnerHtml.Should().Contain("M12 7c-2.76", "The A radio input is checked");
+            iconB.InnerHtml.Should().Contain("M12 2C6.48", "The B radio input is checked");
         }
     }
 }

--- a/tests/StaticInput.UnitTests/Components/RadioTests.cs
+++ b/tests/StaticInput.UnitTests/Components/RadioTests.cs
@@ -43,8 +43,8 @@ namespace StaticInput.UnitTests.Components
             radioA.Should().NotBeNull();
             radioB.Should().NotBeNull();
 
-            radioA.HasAttribute("checked").Should().BeTrue();
-            radioB.HasAttribute("checked").Should().BeFalse();
+            radioA!.HasAttribute("checked").Should().BeTrue();
+            radioB!.HasAttribute("checked").Should().BeFalse();
         }
 
         [Fact]
@@ -56,8 +56,8 @@ namespace StaticInput.UnitTests.Components
             IElement radioA = radioInputs.First(r => r.GetAttribute("value") == "A");
             IElement radioB = radioInputs.First(r => r.GetAttribute("value") == "B");
 
-            IElement? iconA = radioA.ParentElement.QuerySelector(".mud-icon-root");
-            IElement? iconB = radioB.ParentElement.QuerySelector(".mud-icon-root");
+            IElement? iconA = radioA.ParentElement!.QuerySelector(".mud-icon-root");
+            IElement? iconB = radioB.ParentElement!.QuerySelector(".mud-icon-root");
 
             iconA.Should().NotBeNull("The A radio input should be rendered.");
             iconB.Should().NotBeNull("The B radio input should be rendered.");

--- a/tests/StaticInput.UnitTests/Components/RadioTests.cs
+++ b/tests/StaticInput.UnitTests/Components/RadioTests.cs
@@ -1,0 +1,71 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components;
+using MudBlazor.StaticInput;
+using StaticInput.UnitTests.Fixtures;
+using Bunit;
+using AngleSharp.Dom;
+using StaticInput.UnitTests.Viewer.Components.Tests.Radio;
+
+namespace StaticInput.UnitTests.Components
+{
+    public partial class RadioTests(ContextFixture contextFixture) : BaseComponentTest(contextFixture)
+    {
+        [Fact]
+        public void MudStaticRadioGroup_Should_Render_RadioGroup()
+        {
+            IRenderedComponent<MudStaticRadioGroup<string>> comp = Context.RenderComponent<MudStaticRadioGroup<string>>();
+
+            comp.Markup.Replace(" ", string.Empty).Should()
+                .Contain("mud-radio-group")
+                .And.Contain(@"role=""radiogroup""");
+        }
+
+        [Fact]
+        public void MudStaticRadio_Should_Render_Radio()
+        {
+            IRenderedComponent<RadioSingleTest> comp = Context.RenderComponent<RadioSingleTest>();
+
+            comp.Markup.Replace(" ", string.Empty).Should()
+                .Contain("mud-radio")
+                .And.Contain("input")
+                .And.Contain("mud-radio-input")
+                .And.Contain(@"role=""radio""");
+        }
+
+        [Fact]
+        public void MudStaticRadio_Should_Have_Correct_Checked_State()
+        {
+            IRenderedComponent<RadioGroupTest> comp = Context.RenderComponent<RadioGroupTest>();
+
+            IRefreshableElementCollection<IElement> radios = comp.FindAll("input[type='radio']");
+            IElement? radioA = radios.FirstOrDefault(r => r.GetAttribute("value") == "A");
+            IElement? radioB = radios.FirstOrDefault(r => r.GetAttribute("value") == "B");
+
+            radioA.Should().NotBeNull();
+            radioB.Should().NotBeNull();
+
+            radioA.HasAttribute("checked").Should().BeTrue();
+            radioB.HasAttribute("checked").Should().BeFalse();
+        }
+
+        [Fact]
+        public void MudStaticRadio_Icon_Should_Reflect_Checked_State()
+        {
+            IRenderedComponent<RadioGroupTest> comp = Context.RenderComponent<RadioGroupTest>();
+
+            IRefreshableElementCollection<IElement> radioInputs = comp.FindAll("input[type='radio']");
+            IElement radioA = radioInputs.First(r => r.GetAttribute("value") == "A");
+            IElement radioB = radioInputs.First(r => r.GetAttribute("value") == "B");
+
+            IElement? iconA = radioA.ParentElement.QuerySelector(".mud-icon-root");
+            IElement? iconB = radioB.ParentElement.QuerySelector(".mud-icon-root");
+
+            iconA.Should().NotBeNull("L'icône de la radio A doit être rendue.");
+            iconB.Should().NotBeNull("L'icône de la radio B doit être rendue.");
+
+            iconA.InnerHtml.Should().Contain("M12 7c-2.76", "car la radio A est cochée");
+            iconB.InnerHtml.Should().Contain("M12 2C6.48", "car la radio B est décochée");
+        }
+    }
+}

--- a/tests/StaticInput.UnitTests/StaticInput.UnitTests.csproj
+++ b/tests/StaticInput.UnitTests/StaticInput.UnitTests.csproj
@@ -22,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
-    <PackageReference Include="MudBlazor" Version="8.2.0" />
+    <PackageReference Include="MudBlazor" Version="8.*" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR add a static version for the MudRadioGroup and MudRadio. Based off the submission from @sikelio in PR #33 this has been updated to support `EditForms` and `DataAnnotationValidator` as well as utilize Mud components instead of just the css styles. Also adds support for defining Colors and Icons to be used. 

Closes: #32 