### PR TITLE
Fix MudStaticNavGroup Visibility and Animation

### DIFF
--- a/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
+++ b/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
@@ -1,4 +1,6 @@
 
+const initializedElements = new WeakSet();
+
 export function afterWebStarted(blazor) {
     if (blazor) {
         blazor.addEventListener('enhancedload', () => {
@@ -35,8 +37,11 @@ function initialize() {
 }
 
 function initTextFields() {
-    const textFields = document.querySelectorAll('[data-mud-static-type="text-field"]:not([data-mud-static-initialized="true"])');
+    const textFields = document.querySelectorAll('[data-mud-static-type="text-field"]');
     textFields.forEach(inputElement => {
+        if (initializedElements.has(inputElement)) return;
+        initializedElements.add(inputElement);
+
         inputElement.setAttribute('data-mud-static-initialized', 'true');
         const shrinkLabel = inputElement.getAttribute('data-mud-static-shrink') === 'true';
         const showOnFocus = inputElement.getAttribute('data-mud-static-helper-focus') === 'true';
@@ -103,8 +108,11 @@ function initTextFields() {
 }
 
 function initCheckBoxes() {
-    const checkBoxes = document.querySelectorAll('[data-mud-static-type="checkbox"]:not([data-mud-static-initialized="true"])');
+    const checkBoxes = document.querySelectorAll('[data-mud-static-type="checkbox"]');
     checkBoxes.forEach(checkbox => {
+        if (initializedElements.has(checkbox)) return;
+        initializedElements.add(checkbox);
+
         checkbox.setAttribute('data-mud-static-initialized', 'true');
         const name = checkbox.getAttribute('data-mud-static-name');
         const parent = checkbox.closest('.mud-input-control');
@@ -132,8 +140,11 @@ function initCheckBoxes() {
 }
 
 function initSwitches() {
-    const switches = document.querySelectorAll('[data-mud-static-type="switch"]:not([data-mud-static-initialized="true"])');
+    const switches = document.querySelectorAll('[data-mud-static-type="switch"]');
     switches.forEach(switchToggle => {
+        if (initializedElements.has(switchToggle)) return;
+        initializedElements.add(switchToggle);
+
         switchToggle.setAttribute('data-mud-static-initialized', 'true');
         const name = switchToggle.getAttribute('data-mud-static-name');
         const label = switchToggle.closest('label');
@@ -180,8 +191,11 @@ function initSwitches() {
 }
 
 function initRadios() {
-    const radios = document.querySelectorAll('[data-mud-static-type="radio"]:not([data-mud-static-initialized="true"])');
+    const radios = document.querySelectorAll('[data-mud-static-type="radio"]');
     radios.forEach(radio => {
+        if (initializedElements.has(radio)) return;
+        initializedElements.add(radio);
+
         radio.setAttribute('data-mud-static-initialized', 'true');
         radio.addEventListener('change', function () {
             const parentGroup = radio.closest('[data-mud-static-type="radio-group"]');
@@ -223,8 +237,11 @@ function initRadios() {
 }
 
 function initDrawers() {
-    const drawerToggleElements = document.querySelectorAll('[data-mud-static-type="drawer-toggle"]:not([data-mud-static-initialized="true"])');
+    const drawerToggleElements = document.querySelectorAll('[data-mud-static-type="drawer-toggle"]');
     drawerToggleElements.forEach(element => {
+        if (initializedElements.has(element)) return;
+        initializedElements.add(element);
+
         element.setAttribute('data-mud-static-initialized', 'true');
         element.removeEventListener('click', onDrawerToggleClick);
         element.addEventListener('click', onDrawerToggleClick);
@@ -500,8 +517,11 @@ function autoExpand(mudDrawer, variant, breakpoint, position) {
 }
 
 function initNavGroups() {
-    const navGroups = document.querySelectorAll('[data-mud-static-type="nav-group"]:not([data-mud-static-initialized="true"])');
+    const navGroups = document.querySelectorAll('[data-mud-static-type="nav-group"]');
     navGroups.forEach(navGroup => {
+        if (initializedElements.has(navGroup)) return;
+        initializedElements.add(navGroup);
+
         navGroup.setAttribute('data-mud-static-initialized', 'true');
         const button = navGroup.querySelector('button');
         if (button) {
@@ -521,7 +541,9 @@ function initNavGroups() {
                 collapseContainer.style.transition = 'height 250ms cubic-bezier(0.4, 0, 0.2, 1)';
 
                 if (willExpand) {
+                    navElement.classList.add('mud-nav-group-expanded');
                     collapseContainer.classList.remove('invisible');
+                    collapseContainer.style.display = 'block'; // Ensure it's not display: none
                     collapseContainer.setAttribute('aria-hidden', 'false');
                     collapseContainer.classList.add('mud-collapse-entering');
 
@@ -534,6 +556,7 @@ function initNavGroups() {
                         collapseContainer.style.height = 'auto';
                     }, 250);
                 } else {
+                    navElement.classList.remove('mud-nav-group-expanded');
                     const height = wrapper.scrollHeight;
                     collapseContainer.style.height = height + 'px';
 
@@ -547,6 +570,7 @@ function initNavGroups() {
                     setTimeout(() => {
                         collapseContainer.classList.remove('mud-collapse-exiting');
                         collapseContainer.classList.add('invisible');
+                        collapseContainer.style.display = ''; // Reset display
                         collapseContainer.setAttribute('aria-hidden', 'true');
                     }, 250);
                 }

--- a/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
+++ b/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
@@ -550,6 +550,11 @@ function initNavGroups() {
                     // We DO NOT add mud-nav-group-expanded here to avoid the persistent background highlight.
                     // Instead, we only rotate the icon and handle the collapse state.
                     collapseContainer.style.display = 'block';
+                    collapseContainer.style.height = '0px';
+
+                    // Force reflow
+                    collapseContainer.offsetHeight;
+
                     collapseContainer.setAttribute('aria-hidden', 'false');
                     collapseContainer.classList.add('mud-collapse-entering');
 

--- a/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
+++ b/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
@@ -537,46 +537,55 @@ function initNavGroups() {
                 const isCurrentlyExpanded = button.getAttribute('aria-expanded') === "true";
                 const willExpand = !isCurrentlyExpanded;
 
-                // Clear any existing timeouts or styles that might interfere
+                // Clear any existing timeouts
+                if (collapseContainer._mudStaticNavGroupTimeout) {
+                    clearTimeout(collapseContainer._mudStaticNavGroupTimeout);
+                }
+
+                // Reset transient classes and ensure consistent state
+                collapseContainer.classList.remove('mud-collapse-entering', 'mud-collapse-exiting', 'mud-collapse-entered', 'invisible');
                 collapseContainer.style.transition = 'height 250ms cubic-bezier(0.4, 0, 0.2, 1)';
 
                 if (willExpand) {
-                    navElement.classList.add('mud-nav-group-expanded');
-                    collapseContainer.classList.remove('invisible');
-                    collapseContainer.style.display = 'block'; // Ensure it's not display: none
+                    // We DO NOT add mud-nav-group-expanded here to avoid the persistent background highlight.
+                    // Instead, we only rotate the icon and handle the collapse state.
+                    collapseContainer.style.display = 'block';
                     collapseContainer.setAttribute('aria-hidden', 'false');
                     collapseContainer.classList.add('mud-collapse-entering');
 
                     const height = wrapper.scrollHeight;
                     collapseContainer.style.height = height + 'px';
 
-                    setTimeout(() => {
+                    collapseContainer._mudStaticNavGroupTimeout = setTimeout(() => {
                         collapseContainer.classList.remove('mud-collapse-entering');
                         collapseContainer.classList.add('mud-collapse-entered');
                         collapseContainer.style.height = 'auto';
+                        delete collapseContainer._mudStaticNavGroupTimeout;
                     }, 250);
                 } else {
-                    navElement.classList.remove('mud-nav-group-expanded');
                     const height = wrapper.scrollHeight;
                     collapseContainer.style.height = height + 'px';
 
                     // Force reflow
                     collapseContainer.offsetHeight;
 
-                    collapseContainer.classList.remove('mud-collapse-entered');
                     collapseContainer.classList.add('mud-collapse-exiting');
                     collapseContainer.style.height = '0px';
 
-                    setTimeout(() => {
+                    collapseContainer._mudStaticNavGroupTimeout = setTimeout(() => {
                         collapseContainer.classList.remove('mud-collapse-exiting');
                         collapseContainer.classList.add('invisible');
-                        collapseContainer.style.display = ''; // Reset display
+                        collapseContainer.style.display = '';
                         collapseContainer.setAttribute('aria-hidden', 'true');
+                        delete collapseContainer._mudStaticNavGroupTimeout;
                     }, 250);
                 }
 
                 expandIcon.classList.toggle('mud-transform', willExpand);
                 button.setAttribute('aria-expanded', willExpand);
+
+                // Remove focus to fix the persistent "hover" highlight issue
+                button.blur();
             });
         }
     });

--- a/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
+++ b/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
@@ -510,18 +510,49 @@ function initNavGroups() {
                 if (!navElement) return;
                 const collapseContainer = navElement.querySelector('.mud-collapse-container');
                 const expandIcon = navElement.querySelector('.mud-nav-link-expand-icon');
+                const wrapper = collapseContainer ? collapseContainer.querySelector('.mud-collapse-wrapper') : null;
 
-                if (!collapseContainer || !expandIcon) return;
+                if (!collapseContainer || !expandIcon || !wrapper) return;
 
-                const isExpanded = button.getAttribute('aria-expanded') === "true";
+                const isCurrentlyExpanded = button.getAttribute('aria-expanded') === "true";
+                const willExpand = !isCurrentlyExpanded;
 
-                collapseContainer.classList.toggle('mud-collapse-entered', !isExpanded);
-                collapseContainer.classList.toggle('mud-navgroup-collapse', true);
-                collapseContainer.classList.remove('mud-collapse-entering');
-                collapseContainer.setAttribute('aria-hidden', isExpanded);
+                // Clear any existing timeouts or styles that might interfere
+                collapseContainer.style.transition = 'height 250ms cubic-bezier(0.4, 0, 0.2, 1)';
 
-                expandIcon.classList.toggle('mud-transform', !isExpanded);
-                button.setAttribute('aria-expanded', !isExpanded);
+                if (willExpand) {
+                    collapseContainer.classList.remove('invisible');
+                    collapseContainer.setAttribute('aria-hidden', 'false');
+                    collapseContainer.classList.add('mud-collapse-entering');
+
+                    const height = wrapper.scrollHeight;
+                    collapseContainer.style.height = height + 'px';
+
+                    setTimeout(() => {
+                        collapseContainer.classList.remove('mud-collapse-entering');
+                        collapseContainer.classList.add('mud-collapse-entered');
+                        collapseContainer.style.height = 'auto';
+                    }, 250);
+                } else {
+                    const height = wrapper.scrollHeight;
+                    collapseContainer.style.height = height + 'px';
+
+                    // Force reflow
+                    collapseContainer.offsetHeight;
+
+                    collapseContainer.classList.remove('mud-collapse-entered');
+                    collapseContainer.classList.add('mud-collapse-exiting');
+                    collapseContainer.style.height = '0px';
+
+                    setTimeout(() => {
+                        collapseContainer.classList.remove('mud-collapse-exiting');
+                        collapseContainer.classList.add('invisible');
+                        collapseContainer.setAttribute('aria-hidden', 'true');
+                    }, 250);
+                }
+
+                expandIcon.classList.toggle('mud-transform', willExpand);
+                button.setAttribute('aria-expanded', willExpand);
             });
         }
     });

--- a/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
+++ b/src/wwwroot/Extensions.MudBlazor.StaticInput.lib.module.js
@@ -537,22 +537,17 @@ function initNavGroups() {
                 const isCurrentlyExpanded = button.getAttribute('aria-expanded') === "true";
                 const willExpand = !isCurrentlyExpanded;
 
-                // Clear any existing timeouts
                 if (collapseContainer._mudStaticNavGroupTimeout) {
                     clearTimeout(collapseContainer._mudStaticNavGroupTimeout);
                 }
 
-                // Reset transient classes and ensure consistent state
                 collapseContainer.classList.remove('mud-collapse-entering', 'mud-collapse-exiting', 'mud-collapse-entered', 'invisible');
                 collapseContainer.style.transition = 'height 250ms cubic-bezier(0.4, 0, 0.2, 1)';
 
                 if (willExpand) {
-                    // We DO NOT add mud-nav-group-expanded here to avoid the persistent background highlight.
-                    // Instead, we only rotate the icon and handle the collapse state.
                     collapseContainer.style.display = 'block';
                     collapseContainer.style.height = '0px';
 
-                    // Force reflow
                     collapseContainer.offsetHeight;
 
                     collapseContainer.setAttribute('aria-hidden', 'false');
@@ -571,7 +566,6 @@ function initNavGroups() {
                     const height = wrapper.scrollHeight;
                     collapseContainer.style.height = height + 'px';
 
-                    // Force reflow
                     collapseContainer.offsetHeight;
 
                     collapseContainer.classList.add('mud-collapse-exiting');
@@ -588,9 +582,6 @@ function initNavGroups() {
 
                 expandIcon.classList.toggle('mud-transform', willExpand);
                 button.setAttribute('aria-expanded', willExpand);
-
-                // Remove focus to fix the persistent "hover" highlight issue
-                button.blur();
             });
         }
     });

--- a/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
+++ b/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
@@ -23,21 +23,28 @@ namespace StaticInput.UnitTests.Components
             var ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");
 
             menuClasses.Should().NotBeNullOrEmpty();
+            // In static mode with Expanded="true", it starts with mud-collapse-entering (from MudBlazor)
             menuClasses.Should().Contain("mud-collapse-entering");
             ariaValue.Should().Be("false");
 
             await button.ClickAsync();
+            // Wait for JS animation
+            await Task.Delay(500);
 
             menuClasses = await menuGroup.GetAttributeAsync("class");
-            menuClasses.Should().NotContain("mud-collapse-entered").And.NotContain("mud-collapse-entering");
+            menuClasses.Should().NotContain("mud-collapse-entered");
+            menuClasses.Should().Contain("invisible");
 
             ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");
             ariaValue.Should().Be("true");
 
             await button.ClickAsync();
+            // Wait for JS animation
+            await Task.Delay(500);
 
             menuClasses = await menuGroup.GetAttributeAsync("class");
             menuClasses.Should().Contain("mud-collapse-entered");
+            menuClasses.Should().NotContain("invisible");
 
             ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");
             ariaValue.Should().Be("false");

--- a/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
+++ b/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
@@ -29,7 +29,7 @@ namespace StaticInput.UnitTests.Components
 
             await button.ClickAsync();
             // Wait for JS animation
-            await Task.Delay(500);
+            await Task.Delay(600);
 
             menuClasses = await menuGroup.GetAttributeAsync("class");
             menuClasses.Should().NotContain("mud-collapse-entered");
@@ -40,7 +40,7 @@ namespace StaticInput.UnitTests.Components
 
             await button.ClickAsync();
             // Wait for JS animation
-            await Task.Delay(500);
+            await Task.Delay(600);
 
             menuClasses = await menuGroup.GetAttributeAsync("class");
             menuClasses.Should().Contain("mud-collapse-entered");

--- a/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
+++ b/tests/StaticInput.UnitTests/Components/NavMenuTests.cs
@@ -23,7 +23,6 @@ namespace StaticInput.UnitTests.Components
             var ariaValue = await menuGroup.GetAttributeAsync("aria-hidden");
 
             menuClasses.Should().NotBeNullOrEmpty();
-            // In static mode with Expanded="true", it starts with mud-collapse-entering (from MudBlazor)
             menuClasses.Should().Contain("mud-collapse-entering");
             ariaValue.Should().Be("false");
 


### PR DESCRIPTION
This change fixes a bug in `MudStaticNavGroup` where nested items remained invisible after expanding the group from an initially collapsed state in Static SSR. 

The fix involves:
1. Enhancing `initNavGroups` in `Extensions.MudBlazor.StaticInput.lib.module.js` to explicitly remove the `invisible` class upon expansion and re-add it upon collapse.
2. Implementing a manual height animation using the `scrollHeight` of the content wrapper and a 250ms CSS transition, mimicking standard MudBlazor behavior without requiring an interactive lifecycle.
3. Updating the existing unit tests in `NavMenuTests.cs` to include necessary delays for these animations and verify the presence/absence of the `invisible` class.

Visual verification was performed using the TestViewer project, confirming that items appear correctly and the expansion is smooth.

---
*PR created automatically by Jules for task [16877831955550158464](https://jules.google.com/task/16877831955550158464) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-element initialization guards and broader initialization to avoid repeated setup.
  * Initial-load handling and a MutationObserver to auto-run initialization for newly added nodes.
  * Improved navigation group expand/collapse with staged height animations, icon/ARIA/focus synchronization.

* **Bug Fixes**
  * Reset transient animation states and timeouts to prevent visual glitches and inconsistent expansion.

* **Tests**
  * Updated tests to validate staged expand/collapse timing and states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->