### PR TITLE
Bump MudBlazor from 9.0.0 to 9.1.0

### DIFF
--- a/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
+++ b/demo/StaticSample/StaticSample.Client/StaticSample.Client.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Blazr.RenderState.WASM" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
-    <PackageReference Include="MudBlazor" Version="9.0.0" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.3" />
   </ItemGroup>
 

--- a/demo/StaticSample/StaticSample/StaticSample.csproj
+++ b/demo/StaticSample/StaticSample/StaticSample.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MudBlazor" Version="9.0.0" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/MudBlazor.StaticInput.csproj
+++ b/src/MudBlazor.StaticInput.csproj
@@ -31,13 +31,13 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-        <PackageReference Include="MudBlazor" Version="9.0.*" />
+        <PackageReference Include="MudBlazor" Version="9.1.*" />
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.*" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.*" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-        <PackageReference Include="MudBlazor" Version="9.0.*" />
+        <PackageReference Include="MudBlazor" Version="9.1.*" />
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="10.0.*" />
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.*" />
     </ItemGroup>

--- a/tests/StaticInput.UnitTests.Viewer/StaticInput.UnitTests.Viewer.csproj
+++ b/tests/StaticInput.UnitTests.Viewer/StaticInput.UnitTests.Viewer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="9.0.0" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/StaticInput.UnitTests/StaticInput.UnitTests.csproj
+++ b/tests/StaticInput.UnitTests/StaticInput.UnitTests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MudBlazor" Version="9.0.0" />
+    <PackageReference Include="MudBlazor" Version="9.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
• Update MudBlazor dependency from v9.0.0 to v9.1.0
• Applies to demo projects, unit tests, and main library